### PR TITLE
Update upload-action to v4 to fix error

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,6 +13,9 @@ on:
     - cron: '29 11 * * 3'
   push:
     branches: [ "main" ]
+  pull_request:
+    paths:
+      - '.github/workflows/scorecard.yml'
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Got "Create Artifact Container failed: The artifact name SARIF file is not valid." According to https://github.com/actions/upload-artifact/issues/410, upgrading to v4 might be a solution, so testing this.