### PR TITLE
Fix Undo #84

### DIFF
--- a/src/plantuml_gui/static/script.js
+++ b/src/plantuml_gui/static/script.js
@@ -75,7 +75,9 @@ async function initeditor() {
 }
 
 function findChangedLines() {
-    if (history.length < 2) return; // No previous version to compare
+    // historyPointer < 1: even with many history entries, pointer at 0 means
+    // there's no previous entry to diff against (history[-1] is undefined)
+    if (history.length < 2 || historyPointer < 1) return;
 
     const prevText = history[historyPointer - 1];
     const currText = history[historyPointer];

--- a/tests/js/ScriptTests.js
+++ b/tests/js/ScriptTests.js
@@ -167,3 +167,20 @@ end note
     })
 
 });
+
+describe("findChangedLines", function () {
+    beforeEach(function () {
+        history = [];
+        historyPointer = -1;
+        spyOn(window, "getmarkersinglelines").and.stub(); // avoid calling Ace editor marker APIs not available in test
+    });
+
+    it("should not throw when historyPointer is 0", function () {
+        history = ["initial", "change1", "change2"];
+        historyPointer = 0;
+
+        expect(function () {
+            findChangedLines();
+        }).not.toThrow();
+    });
+});

--- a/tests/js/ScriptTests.js
+++ b/tests/js/ScriptTests.js
@@ -172,7 +172,7 @@ describe("findChangedLines", function () {
     beforeEach(function () {
         history = [];
         historyPointer = -1;
-        spyOn(window, "getmarkersinglelines").and.stub(); // avoid calling Ace editor marker APIs not available in test
+        spyOn(window, "setEditorMarkers").and.stub(); // avoid calling Ace editor marker APIs not available in test
     });
 
     it("should not throw when historyPointer is 0", function () {

--- a/tests/js/SpecRunner.html
+++ b/tests/js/SpecRunner.html
@@ -40,6 +40,7 @@ SOFTWARE.
   <script src="lib/jasmine-5.1.2/boot1.js"></script>
 
   <!-- include source files here... -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jsdiff/7.0.0/diff.min.js" integrity="sha512-immo//J6lKoR+nRIFDPxoxfL2nd/0N3w8l4LwH4HSSVovtUjab5kbh4AhixLH5z9mIv37llY9Q2i8AfEDXyYjw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.9.6/ace.js" integrity="sha512-czfWedq9cnMibaqVP2Sw5Aw1PTTabHxMuTOkYkL15cbCYiatPIbxdV0zwhfBZKNODg0zFqmbz8f7rKmd6tfR/Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="../../src/plantuml_gui/static/script.js"></script>
   <!-- include spec files here... -->


### PR DESCRIPTION
This pull request improves the robustness of the `findChangedLines` function and adds new tests to ensure its correct behavior when navigating the editor's history. Additionally, it updates the test runner to include a dependency required for diffing functionality.

**Bug fix and test coverage improvements:**

* Updated the `findChangedLines` function in `script.js` to check that `historyPointer` is at least 1 before attempting to diff, preventing errors when at the start of the history.
* Added a new Jasmine test suite in `ScriptTests.js` to verify that `findChangedLines` does not throw an error when `historyPointer` is 0.

**Test environment updates:**

* Included the `jsdiff` library in `SpecRunner.html` to support diff operations during testing.