### PR TITLE
Version History

### DIFF
--- a/.kiro/skills/pre-commit-checklist/SKILL.md
+++ b/.kiro/skills/pre-commit-checklist/SKILL.md
@@ -14,6 +14,7 @@ Review and update any documentation affected by your changes:
 - **`docs/`** — Update the relevant doc if you changed architecture, routes, data models, the frontend-backend contract, element patterns, or setup steps.
 - **`README.md`** — Update if you changed usage instructions, pre-requisites, or setup steps.
 - **`FEATURES.md`** — Update if you added, removed, or changed a user-facing feature.
+- **`CHANGELOG.md`** — Add new features and bug fixes to the `## [Unreleased]` section. User-facing changes go under `### External`; technical/internal changes go under `### Internal`.
 - **`.kiro/steering/structure.md`** — Update if you added new files, modules, or changed the directory layout.
 - **`.kiro/steering/product.md`** — Update if you changed supported diagram elements or key features.
 - **`.kiro/steering/tech.md`** — Update if you added dependencies, changed tooling, or modified commands.

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -43,6 +43,7 @@ Each diagram element type has its own Python module:
 - `classes.py` - Shared data classes (Ellipse, PolyElement, RectElement)
 - `util.py` - Utility functions
 - `puml_encoder.py` - URL encoding/decoding for diagram sharing
+- `parse_changelog.py` - CHANGELOG.md parser for version history endpoint
 
 ## Naming Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,62 +6,60 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Fixed
+### External
 
-- Fixed undo crash when undoing to first history entry (#84)
+- Fixed undo crash when undoing to first history entry
 - Fixed Save button to save content to file
+- Made generated PNG copyable
+- Added Version History modal showing release notes
 
-### Changed
+### Internal
 
 - Updated project URLs to point to official repository (#93)
 - Updated author and contact emails (#93)
 - Added comments for AbortError handling (#83)
-- Made generated PNG copyable (#77)
 
 ## [0.28] - 2025-08-18
 
-### Added
+### External
 
-- Load and Save buttons
-- Resizable panes with realigning button groups
-- Sequence diagram support: add participants, add messages, edit participant names
-- Diagram type detection function with configurable skip blocks
+- Added Load and Save buttons
+- Added resizable panes with realigning button groups
+- Added sequence diagram support with participants and messages
 
-### Fixed
+### Internal
 
+- Added diagram type detection function with configurable skip blocks
 - Fixed issue where sequence diagram was wrongly identified
 
 ## [0.27] - 2025-04-08
 
-### Added
+### External
 
-- PlantUML syntax highlighter update
-- Mailto hyperlink in usage tab
+- Updated PlantUML syntax highlighter
+- Added mailto hyperlink in usage tab
+- Fixed error where indentation level went negative
+
+### Internal
+
 - Identifier in plantuml.js (#45)
-
-### Fixed
-
-- Fixed error where indentation level went negative (#52)
-
-### Changed
-
 - Updated scorecard workflow trigger
 - Updated upload-action to v4
 
 ## [0.26] - 2025-02-04
 
-### Added
+### External
 
-- Hashed cache busting for static assets
+- Added hashed cache busting for static assets
 
-### Fixed
+### Internal
 
 - Resolved #31
 - Resolved #33
 
 ## [0.25] - 2024-12-04
 
-### Added
+### External
 
 - Initial versioned release
 - Interactive PlantUML activity diagram editing
@@ -71,3 +69,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Double-click to edit text
 - Pan and zoom support
 - Line highlighting on hover/click
+
+### Internal

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -12,6 +12,7 @@ PlantUML Activity Diagram documentation: [Activity Diagram (New Syntax) on plant
 - Copy / Paste buttons to replace from or copy to clipboard
 - Undo / Redo using buttons or CTRL + X / CTRL + Y
 - Syntax and server error popups
+- Version History modal showing external changelog
 
 
 

--- a/docs/frontend_backend_contract.md
+++ b/docs/frontend_backend_contract.md
@@ -97,3 +97,23 @@ For JSON responses (line numbers), the frontend uses them to highlight the corre
 const data = await response.json();
 getmarker(data.result);
 ```
+
+## Changelog
+
+The Version History modal fetches release notes via a simple GET:
+
+```javascript
+const response = await fetch('/changelog');
+const data = await response.json();
+```
+
+Response is a JSON array:
+
+```json
+[
+  {"version": "0.28", "date": "2025-08-18", "entries": ["Added Load and Save buttons", ...]},
+  ...
+]
+```
+
+No request body. Only External changelog entries are included.

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -5,6 +5,7 @@ All routes are defined in `app.py` on the `plantuml` Blueprint (mounted at `/`).
 ## General
 
 - **GET /** — Serves `index.html`. No input. Returns HTML.
+- **GET /changelog** — No input. Returns: JSON array of version objects with `version`, `date`, and `entries` (list of strings). Only includes External changelog entries.
 
 ## Render
 

--- a/src/plantuml_gui/app.py
+++ b/src/plantuml_gui/app.py
@@ -87,6 +87,7 @@ from .if_statements import (
 )
 from .merge import get_index_merge
 from .note import delete_note, edit_note, get_note_line, get_note_text, note_toggle
+from .parse_changelog import parse_changelog
 from .participant import (
     add_message,
     add_participant,
@@ -976,10 +977,14 @@ def getarrowline():
     return jsonify({"result": result})  # int is not accepted by flask
 
 
-################################# ENCODE DECODE #################################
-################################# ENCODE DECODE #################################
-################################# ENCODE DECODE #################################
-################################# ENCODE DECODE #################################
+################################# CHANGELOG #################################
+
+
+@plantuml.route("/changelog")
+def changelog():
+    return jsonify(parse_changelog())
+
+
 ################################# ENCODE DECODE #################################
 
 

--- a/src/plantuml_gui/parse_changelog.py
+++ b/src/plantuml_gui/parse_changelog.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2024 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import re
+from pathlib import Path
+
+
+def parse_changelog(
+    path: Path | None = None,
+) -> list[dict[str, str | list[str]]]:
+    """Parse CHANGELOG.md and extract External entries per version.
+
+    Returns a list of dicts with keys: version, date, entries.
+    """
+    if path is None:
+        path = Path(__file__).parent.parent.parent / "CHANGELOG.md"
+
+    content = path.read_text(encoding="utf-8")
+    versions: list[dict[str, str | list[str]]] = []
+    current: dict[str, str | list[str]] | None = None
+    in_external = False
+
+    for line in content.splitlines():
+        # Detect version headers like "## [0.28] - 2025-08-18" or "## [Unreleased]"
+        version_match = re.match(r"^## \[(.+?)\]\s*-?\s*(.*)", line)
+        if version_match:
+            # Save the previous version section before starting a new one
+            if current:
+                versions.append(current)
+            current = {
+                "version": version_match.group(1),
+                "date": version_match.group(2).strip(),
+                "entries": [],
+            }
+            in_external = False
+            continue
+
+        # Skip lines before the first version header
+        if current is None:
+            continue
+
+        # Track whether we're inside an ### External subsection
+        if line.strip() == "### External":
+            in_external = True
+            continue
+        elif line.startswith("### "):
+            # Any other subsection (e.g. ### Internal) exits External
+            in_external = False
+            continue
+
+        # Collect bullet points from the External subsection
+        if in_external and line.startswith("- "):
+            entries = current["entries"]
+            assert isinstance(entries, list)  # type narrowing for mypy
+            entries.append(line[2:])
+
+    # Don't forget the last version section
+    if current:
+        versions.append(current)
+
+    return versions

--- a/src/plantuml_gui/static/script.js
+++ b/src/plantuml_gui/static/script.js
@@ -850,3 +850,21 @@ function checkDiagramType(puml) {
 
     return "unknown";
 }
+
+async function showChangelog() {
+    const body = document.getElementById('changelog-body');
+    try {
+        const response = await fetch('/changelog');
+        const data = await response.json();
+        body.innerHTML = data
+            .filter(v => v.version !== 'Unreleased')
+            .map(v => {
+                const items = v.entries.map(e => `<li>${e}</li>`).join('');
+                const date = v.date ? `<small class="text-muted">${v.date}</small>` : '';
+                return `<h4>v${v.version}</h4>${date}<ul>${items}</ul>`;
+            }).join('<hr>');
+    } catch (error) {
+        body.innerHTML = '<p>Failed to load changelog.</p>';
+    }
+    $('#changelog-modal').modal('show');
+}

--- a/src/plantuml_gui/templates/index.html
+++ b/src/plantuml_gui/templates/index.html
@@ -93,6 +93,7 @@ SOFTWARE.
             </div>
             <div class="btn-group" id="btn-group-4" role="group" aria-label="Basic example">
                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#usageModal">Help</button>
+                <button type="button" class="btn btn-info" id="changelog-btn" onclick="showChangelog()">Version History</button>
           </div>
         </div>
     </div>
@@ -857,6 +858,24 @@ aria-hidden="true">
 
 
 
+
+<div class="modal fade" id="changelog-modal" tabindex="-1" role="dialog" aria-labelledby="changelogModalTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="changelogModalTitle">Version History</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body" id="changelog-body">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 <script>
     (async function() {

--- a/src/plantuml_gui/templates/index.html
+++ b/src/plantuml_gui/templates/index.html
@@ -63,7 +63,7 @@ SOFTWARE.
   <div id=popup>Error message</div>
   <div id="left-side">
     <div id="header" class="d-flex flex-column">
-        <h2>PlantUML Interactive Editor <span id="version">v{{version}}</span></h2>
+        <h2>PlantUML Interactive Editor <span id="version" onclick="showChangelog()" style="cursor:pointer" title="Version History">v{{version}}</span></h2>
         <div class="button-groups btn-toolbar">
             <div class="btn-group" id="btn-group-1" role="group" aria-label="Basic example">
               <div class="btn-group" role="group">
@@ -93,7 +93,6 @@ SOFTWARE.
             </div>
             <div class="btn-group" id="btn-group-4" role="group" aria-label="Basic example">
                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#usageModal">Help</button>
-                <button type="button" class="btn btn-info" id="changelog-btn" onclick="showChangelog()">Version History</button>
           </div>
         </div>
     </div>


### PR DESCRIPTION
- Add parse_changelog.py to extract External entries from CHANGELOG.md
- Add GET /changelog Flask route returning version data as JSON
- Add Version History button and modal in the frontend
- Restructure CHANGELOG.md with External/Internal subsections