### PR TITLE
ci: deploy from summer branch, run pipelines on all PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,8 +2,6 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
-    branches: [summer, main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [summer, main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,6 +2,9 @@ name: pre-commit
 
 on:
   pull_request:
+    branches: [main, summer]
+  push:
+    branches: [main, summer]
 
 jobs:
   pre-commit:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,7 +2,6 @@ name: Python application
 
 on:
   push:
-    branches: [ "summer" ]
   pull_request:
 
 permissions:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,7 +2,9 @@ name: Python application
 
 on:
   push:
+    branches: [main, summer]
   pull_request:
+    branches: [main, summer]
 
 permissions:
   contents: read

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,9 +2,8 @@ name: Python application
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "summer" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: '29 11 * * 3'
   push:
-    branches: [ "main" ]
+    branches: [main, summer]
   pull_request:
     paths:
       - '.github/workflows/scorecard.yml'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to adjust which branches trigger CI jobs. The main changes expand the branches for pre-commit checks and restrict the Python application workflow to the `summer` branch.

Workflow trigger updates:

* [`.github/workflows/pre-commit.yml`](diffhunk://#diff-ac5eead3f3ce4863c524fff031a87b7aecccb4a0493df087a4e1c704a1505036L6-R6): Modified the `push` event to trigger on both the `summer` and `main` branches instead of only `main`.
* [`.github/workflows/python-app.yml`](diffhunk://#diff-d7b3e1cc0b909c52439e5d8d3f602f70644d0f6b62a54825968d819f7a5bee89L5-L7): Changed the `push` event to trigger only on the `summer` branch instead of `main`, and removed the `pull_request` trigger for `main`.