### PR TITLE
Feature/delete participant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### External
 
+- Added delete participant for sequence diagrams (right-click on participant, cascade deletes messages)
 - Fixed undo crash when undoing to first history entry
 - Fixed Save button to save content to file
 - Made generated PNG copyable

--- a/docs/frontend_backend_contract.md
+++ b/docs/frontend_backend_contract.md
@@ -57,9 +57,9 @@ Used by: deleteActivity, detachActivity, breakActivity, checkBackward, addNoteAc
 `sequence.js` handles sequence diagram interactions:
 
 - **addParticipant:** `{plantuml, svg, cx}` — cx is the x-coordinate of the click
-- **deleteParticipant:** `{plantuml, svg, cx}`
 - **getParticipantName:** `{plantuml, svg, svgelement}`
 - **editParticipantName:** `{plantuml, svg, name, svgelement}`
+- **deleteParticipant:** `{plantuml, svg, svgelement}`
 - **addMessage:** `{plantuml, svg, message, svgelement, firstcoordinates, secondcoordinates}` — coordinates are `[x, y]` arrays from two clicks
 - **checkIfInsideParticipant:** `{plantuml, svg, coordinates}` — coordinates is `[x, y]`
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -118,4 +118,4 @@ All routes are organized into Blueprints: `shared_bp` (in `shared/routes.py`) fo
 - **POST /checkIfInsideParticipant** — Input: `plantuml`, `svg`, `coordinates` ([x,y]). Returns: JSON `{"isValid": bool}`.
 - **POST /getParticipantName** — Input: `plantuml`, `svg`, `svgelement`. Returns: participant name string.
 - **POST /editParticipantName** — Input: `plantuml`, `svg`, `name`, `svgelement`. Returns: modified puml.
-- **POST /deleteParticipant** — Input: `plantuml`, `svg`, `cx` (float). Returns: modified puml.
+- **POST /deleteParticipant** — Input: `plantuml`, `svg`, `svgelement`. Returns: modified puml.

--- a/src/plantuml_gui/sequence/participant.py
+++ b/src/plantuml_gui/sequence/participant.py
@@ -135,3 +135,19 @@ def edit_participant_name(puml: str, svg: str, newname: str, svgelement: str) ->
     count = index_of_clicked_participant(svg, svgelement)
     participant = diagram.participants[count - 1]
     return puml.replace(participant.name, newname)
+
+
+def delete_participant(puml: str, svg: str, svgelement: str) -> str:
+    """Delete a participant and all messages referencing it (cascade)."""
+    diagram = Diagram.from_svg(svg, puml)
+    count = index_of_clicked_participant(svg, svgelement)
+    participant = diagram.participants[count - 1]
+    lines = puml.splitlines()
+
+    lines_to_remove = {participant.index}
+    for msg in diagram.messages:
+        if msg.from_participant == participant or msg.to_participant == participant:
+            lines_to_remove.add(msg.index)
+
+    lines = [line for i, line in enumerate(lines) if i not in lines_to_remove]
+    return "\n".join(lines)

--- a/src/plantuml_gui/sequence/routes.py
+++ b/src/plantuml_gui/sequence/routes.py
@@ -28,6 +28,7 @@ from .participant import (
     add_message,
     add_participant,
     check_if_inside_participant,
+    delete_participant,
     edit_participant_name,
     get_participant_name,
 )
@@ -82,3 +83,12 @@ def editparticipantname():
     name = data["name"]
     svgelement = data["svgelement"]
     return edit_participant_name(puml, svg, name, svgelement)
+
+
+@sequence_bp.route("/deleteParticipant", methods=["POST"])
+def deleteparticipant():
+    data = request.get_json()
+    puml = data["plantuml"]
+    svg = data["svg"]
+    svgelement = data["svgelement"]
+    return delete_participant(puml, svg, svgelement)

--- a/src/plantuml_gui/static/script.js
+++ b/src/plantuml_gui/static/script.js
@@ -517,7 +517,8 @@ function addSequenceEventListeners() {
 
     document.addEventListener('click', function(e) {
         var menuIds = [
-            'sequence-menu'
+            'sequence-menu',
+            'participant-menu'
         ];
 
         menuIds.forEach(function(id) {

--- a/src/plantuml_gui/static/sequence.js
+++ b/src/plantuml_gui/static/sequence.js
@@ -69,6 +69,10 @@ function sequenceEventListeners() {
         id: 'addParticipant',
         endpoint: 'addParticipant',
         arguments: {}
+    }, {
+        id: 'deleteParticipant',
+        endpoint: 'deleteParticipant',
+        arguments: {}
     }];
 
     sequenceList.forEach(item => {
@@ -81,7 +85,9 @@ function sequenceEventListeners() {
                     'plantuml': plantuml,
                     'svg': svg.innerHTML,
                     'svgelement': lastclickedsvgelement.outerHTML,
-                    'cx' : firstClickCoordinates[0]
+                }
+                if (firstClickCoordinates) {
+                    toBeStringified['cx'] = firstClickCoordinates[0];
                 }
                 if (item.arguments) {
                     for (let [key, value] of Object.entries(item.arguments)) {
@@ -248,6 +254,16 @@ async function setHandlersForSequenceDiagram(pumlcontent, element) {
 
                 svgelement.addEventListener('mouseout', function() {
                     svgelement.setAttribute('fill', rectcolor)
+                });
+
+                svgelement.addEventListener('contextmenu', function(e) {
+                    lastclickedsvgelement = svgelement;
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var contextMenu = document.getElementById('participant-menu');
+                    contextMenu.style.display = 'block';
+                    contextMenu.style.left = e.pageX + 'px';
+                    contextMenu.style.top = e.pageY + 'px';
                 });
             }
             index++

--- a/src/plantuml_gui/templates/partials/sequence_menus.html
+++ b/src/plantuml_gui/templates/partials/sequence_menus.html
@@ -55,3 +55,7 @@
   <li><a class="dropdown-item" href="#" id="addParticipant">Add Participant</a></li>
   <li><a class="dropdown-item" href="#" id="addMessage">Add Message</a></li>
 </div>
+
+<div class="dropdown-menu" id="participant-menu">
+  <li><a class="dropdown-item" href="#" id="deleteParticipant">Delete Participant</a></li>
+</div>

--- a/tests/e2e/test_sequence_delete.py
+++ b/tests/e2e/test_sequence_delete.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2025 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for sequence diagram delete participant JS logic."""
+
+
+class TestCheckIfParticipant:
+    def test_identifies_participant_rect(self, app_url, page):
+        """checkIfParticipant returns true for a rect with participant style."""
+        result = page.evaluate("""() => {
+            const container = document.createElement('div');
+            container.innerHTML = `
+                <rect fill="#E2E2F0" height="30" rx="2.5" ry="2.5"
+                      style="stroke:#181818;stroke-width:0.5;" width="41" x="5" y="5"></rect>
+                <text>Alice</text>
+            `;
+            const elements = container.querySelectorAll('*');
+            return checkIfParticipant(elements, 0);
+        }""")
+        assert result is True
+
+    def test_rejects_non_participant_rect(self, app_url, page):
+        """checkIfParticipant returns false for a rect with different style."""
+        result = page.evaluate("""() => {
+            const container = document.createElement('div');
+            container.innerHTML = `
+                <rect fill="#E2E2F0" height="30" rx="2.5" ry="2.5"
+                      style="stroke:#000000;stroke-width:1.5;" width="41" x="5" y="5"></rect>
+            `;
+            const elements = container.querySelectorAll('*');
+            return checkIfParticipant(elements, 0);
+        }""")
+        assert result is False
+
+    def test_rejects_non_rect_element(self, app_url, page):
+        """checkIfParticipant returns false for non-rect elements."""
+        result = page.evaluate("""() => {
+            const container = document.createElement('div');
+            container.innerHTML = `
+                <line style="stroke:#181818;stroke-width:0.5;" x1="5" x2="5" y1="0" y2="50"></line>
+            `;
+            const elements = container.querySelectorAll('*');
+            return checkIfParticipant(elements, 0);
+        }""")
+        assert result is False

--- a/tests/sequence/test_participant.py
+++ b/tests/sequence/test_participant.py
@@ -281,3 +281,93 @@ Bob <--> Alice: Hello
                 content_type="application/json",
             )
             assert response.data.decode("utf-8") == "Alice"
+
+    def test_delete_participant_no_messages(self, client):
+        test_data = {
+            "plantuml": """@startuml
+participant Alice
+participant Bob
+@enduml""",
+        }
+        test_data["svg"] = extract_g_element(
+            _create_svg_from_uml(test_data["plantuml"])
+        )
+        test_data["svgelement"] = extract_participant_rect(test_data["svg"], 0)
+        with client:
+            response = client.post(
+                "/deleteParticipant",
+                data=json.dumps(test_data),
+                content_type="application/json",
+            )
+            expected_puml = """@startuml
+participant Bob
+@enduml"""
+            assert response.data.decode("utf-8") == expected_puml
+
+    def test_delete_participant_with_messages(self, client):
+        test_data = {
+            "plantuml": """@startuml
+participant Alice
+participant Bob
+Alice -> Bob: Hello
+Bob -> Alice: Hi
+@enduml""",
+        }
+        test_data["svg"] = extract_g_element(
+            _create_svg_from_uml(test_data["plantuml"])
+        )
+        test_data["svgelement"] = extract_participant_rect(test_data["svg"], 0)
+        with client:
+            response = client.post(
+                "/deleteParticipant",
+                data=json.dumps(test_data),
+                content_type="application/json",
+            )
+            expected_puml = """@startuml
+participant Bob
+@enduml"""
+            assert response.data.decode("utf-8") == expected_puml
+
+    def test_delete_participant_self_message(self, client):
+        test_data = {
+            "plantuml": """@startuml
+participant Alice
+participant Bob
+Alice -> Alice: Think
+Alice -> Bob: Done
+@enduml""",
+        }
+        test_data["svg"] = extract_g_element(
+            _create_svg_from_uml(test_data["plantuml"])
+        )
+        test_data["svgelement"] = extract_participant_rect(test_data["svg"], 0)
+        with client:
+            response = client.post(
+                "/deleteParticipant",
+                data=json.dumps(test_data),
+                content_type="application/json",
+            )
+            expected_puml = """@startuml
+participant Bob
+@enduml"""
+            assert response.data.decode("utf-8") == expected_puml
+
+    def test_delete_last_participant(self, client):
+        test_data = {
+            "plantuml": """@startuml
+participant Alice
+@enduml""",
+        }
+        test_data["svg"] = extract_g_element(
+            _create_svg_from_uml(test_data["plantuml"])
+        )
+        test_data["svgelement"] = extract_participant_rect(test_data["svg"], 0)
+        with client:
+            response = client.post(
+                "/deleteParticipant",
+                data=json.dumps(test_data),
+                content_type="application/json",
+            )
+            expected_puml = """@startuml
+@enduml"""
+            assert response.data.decode("utf-8") == expected_puml


### PR DESCRIPTION
This pull request adds the ability to delete a participant from a sequence diagram (via right-click), which also cascades to delete all messages referencing that participant. The feature is implemented across the backend, frontend, and documentation, and is covered by both end-to-end and unit tests. 

**Feature: Delete Participant with Cascade Message Removal**
- Added backend logic in `participant.py` to delete a participant and all associated messages from the PlantUML source when requested.
- Exposed a new `/deleteParticipant` POST endpoint in the backend, accepting `plantuml`, `svg`, and `svgelement` to identify and remove the participant. [[1]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dR86-R94) [[2]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dR31)
- Updated frontend JavaScript to add a context menu for participants, enabling delete via right-click, and wired up the new endpoint. [[1]](diffhunk://#diff-91586af16c8a3e1ddb8a2e48f65bdd7ff26709fc3aab83dfa3b83c11d8f187f3R72-R75) [[2]](diffhunk://#diff-91586af16c8a3e1ddb8a2e48f65bdd7ff26709fc3aab83dfa3b83c11d8f187f3R258-R267) [[3]](diffhunk://#diff-ec323750c99a2affbdba0b340a6e83ae3da6c6854c8b65235a713965de025aabL520-R521) [[4]](diffhunk://#diff-756941d055cc1228a9a3f0ace1c082bb43b635b5738aef20d5b1a0f46b98b1ceR58-R61)
- Added comprehensive tests: new e2e tests for the JS logic and backend unit tests for various delete scenarios, including edge cases. [[1]](diffhunk://#diff-84e14e494545a06d4236bcb517eaa18f9f0f981a8b432d80c571e88e9a5e8ce5R1-R66) [[2]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fR284-R373)