### PR TITLE
Fix/xss sequence routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Internal
+
+- Fixed reflected XSS in sequence routes by returning `jsonify` instead of raw strings
+
 ## [0.29] - 2026-06-18
 
 ### External

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Internal
 
 - Fixed reflected XSS in sequence routes by returning `jsonify` instead of raw strings
+- Fixed stored XSS in `edit_participant_name` by escaping user input with `html.escape` before writing to puml
 
 ## [0.29] - 2026-06-18
 

--- a/docs/frontend_backend_contract.md
+++ b/docs/frontend_backend_contract.md
@@ -14,7 +14,8 @@ These three fields together give the backend everything it needs to identify wha
 
 ## Common Response Format
 
-- **Modified puml** — The majority of routes return plain text (the full modified puml string). The frontend calls `setPuml(responseText)` which indents and sets the editor value, triggering a re-render.
+- **Modified puml (activity routes)** — Activity routes return plain text (the full modified puml string). The frontend calls `setPuml(responseText)` which indents and sets the editor value, triggering a re-render.
+- **Modified puml (sequence routes)** — Sequence routes return `jsonify({"plantuml": updated_puml})`. The frontend parses JSON and calls `setPuml(data.plantuml)`.
 - **JSON results** — Routes that return line numbers or boolean checks use `jsonify({"result": value})`. Some return additional fields like `{"result": bool, "type": str}`.
 
 ## activity.js Requests
@@ -56,12 +57,12 @@ Used by: deleteActivity, detachActivity, breakActivity, checkBackward, addNoteAc
 
 `sequence.js` handles sequence diagram interactions:
 
-- **addParticipant:** `{plantuml, svg, svgelement, direction}` — direction is 'left' or 'right'
-- **getParticipantName:** `{plantuml, svg, svgelement}`
-- **editParticipantName:** `{plantuml, svg, name, svgelement}`
-- **deleteParticipant:** `{plantuml, svg, svgelement}`
-- **addMessage:** `{plantuml, svg, message, svgelement, firstcoordinates, secondcoordinates}` — coordinates are `[x, y]` arrays from two clicks
-- **checkIfInsideParticipant:** `{plantuml, svg, coordinates}` — coordinates is `[x, y]`
+- **addParticipant:** `{plantuml, svg, svgelement, direction}` — direction is 'left' or 'right'; returns `{"plantuml": updated_puml}`
+- **getParticipantName:** `{plantuml, svg, svgelement}`; returns `{"name": participant_name}`
+- **editParticipantName:** `{plantuml, svg, name, svgelement}`; returns `{"plantuml": updated_puml}`
+- **deleteParticipant:** `{plantuml, svg, svgelement}`; returns `{"plantuml": updated_puml}`
+- **addMessage:** `{plantuml, svg, message, svgelement, firstcoordinates, secondcoordinates}` — coordinates are `[x, y]` arrays from two clicks; returns `{"plantuml": updated_puml}`
+- **checkIfInsideParticipant:** `{plantuml, svg, coordinates}` — coordinates is `[x, y]`; returns `{"isValid": bool}`
 
 ## script.js Requests
 
@@ -81,7 +82,7 @@ For sequence diagrams, the frontend computes `cx` from the clicked rect's x + wi
 
 ## Response Handling
 
-The frontend handles responses uniformly:
+Activity routes return plain text; the frontend reads it directly:
 
 ```javascript
 const response = await fetch(endpoint, { method: 'POST', headers: {...}, body: JSON.stringify(payload) });
@@ -89,14 +90,14 @@ const pumlcontentcode = await response.text();
 setPuml(pumlcontentcode);
 ```
 
-`setPuml()` processes fork/switch keywords, re-indents the puml, and sets the Ace editor value — which triggers the debounced `renderPlantUml()` to re-render the diagram.
-
-For JSON responses (line numbers), the frontend uses them to highlight the corresponding editor line:
+Sequence routes return JSON; the frontend parses and extracts the field:
 
 ```javascript
 const data = await response.json();
-getmarker(data.result);
+setPuml(data.plantuml); // or data.name for getParticipantName
 ```
+
+`setPuml()` processes fork/switch keywords, re-indents the puml, and sets the Ace editor value — which triggers the debounced `renderPlantUml()` to re-render the diagram.
 
 ## Changelog
 

--- a/src/plantuml_gui/sequence/participant.py
+++ b/src/plantuml_gui/sequence/participant.py
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import html
 import re
 from typing import List
 
@@ -138,7 +139,8 @@ def edit_participant_name(puml: str, svg: str, newname: str, svgelement: str) ->
     diagram = Diagram.from_svg(svg, puml)
     count = index_of_clicked_participant(svg, svgelement)
     participant = diagram.participants[count - 1]
-    return puml.replace(participant.name, newname)
+    safe_newname = html.escape(newname, quote=True)
+    return puml.replace(participant.name, safe_newname)
 
 
 def delete_participant(puml: str, svg: str, svgelement: str) -> str:

--- a/src/plantuml_gui/sequence/routes.py
+++ b/src/plantuml_gui/sequence/routes.py
@@ -43,7 +43,7 @@ def addparticipant():
     svg = data["svg"]
     svgelement = data["svgelement"]
     direction = data["direction"]
-    return add_participant(puml, svg, svgelement, direction)
+    return jsonify({"plantuml": add_participant(puml, svg, svgelement, direction)})
 
 
 @sequence_bp.route("/addMessage", methods=["POST"])
@@ -54,7 +54,13 @@ def addmessage():
     message = data["message"]
     firstcoordinates = data["firstcoordinates"]
     secondcoordinates = data["secondcoordinates"]
-    return add_message(puml, svg, message, firstcoordinates, secondcoordinates)
+    return jsonify(
+        {
+            "plantuml": add_message(
+                puml, svg, message, firstcoordinates, secondcoordinates
+            )
+        }
+    )
 
 
 @sequence_bp.route("/checkIfInsideParticipant", methods=["POST"])
@@ -73,7 +79,7 @@ def getparticipantname():
     puml = data["plantuml"]
     svg = data["svg"]
     svgelement = data["svgelement"]
-    return get_participant_name(puml, svg, svgelement)
+    return jsonify({"name": get_participant_name(puml, svg, svgelement)})
 
 
 @sequence_bp.route("/editParticipantName", methods=["POST"])
@@ -83,7 +89,7 @@ def editparticipantname():
     svg = data["svg"]
     name = data["name"]
     svgelement = data["svgelement"]
-    return edit_participant_name(puml, svg, name, svgelement)
+    return jsonify({"plantuml": edit_participant_name(puml, svg, name, svgelement)})
 
 
 @sequence_bp.route("/deleteParticipant", methods=["POST"])
@@ -92,4 +98,4 @@ def deleteparticipant():
     puml = data["plantuml"]
     svg = data["svg"]
     svgelement = data["svgelement"]
-    return delete_participant(puml, svg, svgelement)
+    return jsonify({"plantuml": delete_participant(puml, svg, svgelement)})

--- a/src/plantuml_gui/static/sequence.js
+++ b/src/plantuml_gui/static/sequence.js
@@ -31,8 +31,8 @@ function sequenceEventListeners() {
                     'secondcoordinates': secondClickCoordinates,
                 }),
             });
-            const pumlcontentcode = await response.text()
-            setPuml(pumlcontentcode)
+            const data = await response.json();
+            setPuml(data.plantuml)
         } catch (error) {
             displayErrorMessage(`Error with fetch API: ${error.message}`, error);
         }
@@ -57,8 +57,8 @@ function sequenceEventListeners() {
                     'svgelement': lastclickedsvgelement.outerHTML
                 }),
             });
-            const pumlcontentcode = await response.text();
-            setPuml(pumlcontentcode);
+            const data = await response.json();
+            setPuml(data.plantuml);
         } catch (error) {
             displayErrorMessage(`Error with fetch API: ${error.message}`, error);
         }
@@ -102,8 +102,8 @@ function sequenceEventListeners() {
                     },
                     body: JSON.stringify(toBeStringified)
                 });
-                const pumlcontentcode = await response.text();
-                setPuml(pumlcontentcode);
+                const data = await response.json();
+                setPuml(data.plantuml);
             } catch (error) {
                 displayErrorMessage(`Error with fetch API: ${error.message}`, error);
             }
@@ -232,7 +232,7 @@ async function setHandlersForSequenceDiagram(pumlcontent, element) {
                                 'svgelement': svgelement.outerHTML
                             })
                         });
-                        $('#participant-name-text').val(await response.text());
+                        $('#participant-name-text').val((await response.json()).name);
                         $('#participant-name-modalForm').modal('show');
                         $('#participant-name-modalForm').on('shown.bs.modal', function () {
                             $('#participant-name-text').trigger('focus');

--- a/tests/sequence/test_participant.py
+++ b/tests/sequence/test_participant.py
@@ -94,7 +94,7 @@ participant bob
 participant bob
 participant participant1
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_add_participant_left(self, client):
         test_data = {
@@ -117,7 +117,7 @@ participant bob
 participant participant1
 participant bob
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_add_participant_right_with_messages(self, client):
         test_data = {
@@ -150,7 +150,7 @@ bob -> fred: Hello
 fred -> bob: Bye
 
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_add_participant_number_after_deletion(self, client):
         """Adding a participant after deleting one should increment past the highest existing number."""
@@ -176,7 +176,7 @@ participant participant1
 participant participant4
 participant participant3
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_add_message(self, client):
         test_data = {
@@ -200,7 +200,7 @@ participant bob
 participant fred
 bob -> fred: hello fred
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_edit_participant_name(self, client):
         test_data = {
@@ -226,7 +226,7 @@ participant fred
 bobby -> fred: test
 fred -> bobby: test2
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_edit_participant_name_selfmessage(self, client):
         test_data = {
@@ -252,7 +252,7 @@ participant bob
 participant fred
 bob -> bob: hello
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_checkifinsideparticipant(self, client):
         test_data = {
@@ -310,7 +310,7 @@ Bob <--> Alice: Hello
                 data=json.dumps(test_data),
                 content_type="application/json",
             )
-            assert response.data.decode("utf-8") == "Alice"
+            assert response.get_json()["name"] == "Alice"
 
     def test_delete_participant_no_messages(self, client):
         test_data = {
@@ -332,7 +332,7 @@ participant Bob
             expected_puml = """@startuml
 participant Bob
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_delete_participant_with_messages(self, client):
         test_data = {
@@ -356,7 +356,7 @@ Bob -> Alice: Hi
             expected_puml = """@startuml
 participant Bob
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_delete_participant_self_message(self, client):
         test_data = {
@@ -380,7 +380,7 @@ Alice -> Bob: Done
             expected_puml = """@startuml
 participant Bob
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml
 
     def test_delete_last_participant(self, client):
         test_data = {
@@ -400,4 +400,4 @@ participant Alice
             )
             expected_puml = """@startuml
 @enduml"""
-            assert response.data.decode("utf-8") == expected_puml
+            assert response.get_json()["plantuml"] == expected_puml


### PR DESCRIPTION
This pull request makes important security and API consistency improvements to the sequence diagram routes and updates the frontend-backend contract to reflect these changes following GitHub Code Scanning review of PR #127 . The most significant updates include fixing XSS vulnerabilities, standardizing sequence route responses to JSON, updating frontend and backend code to handle the new response format, and ensuring tests align with the updated API.

This fix is scoped to the sequence routes only. Activity routes also return raw strings but were not changed here — most activity operations do not embed free-text user input in the response, and  CodeQL did not flag them. A follow-up should audit activity routes  that accept free text (editText, editTextIf, editNote, editGroup,  editTextWhile) for the same pattern.

**Security Fixes:**

* Fixed a reflected XSS vulnerability in sequence routes by returning responses via `jsonify` instead of raw strings. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R13) [[2]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL46-R46) [[3]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL57-R63) [[4]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL76-R82) [[5]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL86-R92) [[6]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL95-R101)
* Fixed a stored XSS vulnerability in `edit_participant_name` by escaping user input with `html.escape` before writing to the puml. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R13) [[2]](diffhunk://#diff-0f65544bc3b1131ab09acfb86c197e3ffc4b182a79d63c3007fb12d8f0e070d1R25) [[3]](diffhunk://#diff-0f65544bc3b1131ab09acfb86c197e3ffc4b182a79d63c3007fb12d8f0e070d1L141-R143)

**API and Contract Changes:**

* All sequence diagram routes now return JSON responses (e.g., `{"plantuml": updated_puml}`), instead of plain text, for consistency and safety. [[1]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL46-R46) [[2]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL57-R63) [[3]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL76-R82) [[4]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL86-R92) [[5]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL95-R101)
* Updated documentation to reflect the new response formats and clarify the contract for sequence and activity routes. [[1]](diffhunk://#diff-6175e90722503185d14844d63b5939f41380290c9e5a2727fea835f3d334d88bL17-R18) [[2]](diffhunk://#diff-6175e90722503185d14844d63b5939f41380290c9e5a2727fea835f3d334d88bL59-R65) [[3]](diffhunk://#diff-6175e90722503185d14844d63b5939f41380290c9e5a2727fea835f3d334d88bL84-R101)

**Frontend Updates:**

* Modified `sequence.js` to parse JSON responses and extract the relevant fields, instead of reading plain text, for all sequence diagram interactions. [[1]](diffhunk://#diff-91586af16c8a3e1ddb8a2e48f65bdd7ff26709fc3aab83dfa3b83c11d8f187f3L34-R35) [[2]](diffhunk://#diff-91586af16c8a3e1ddb8a2e48f65bdd7ff26709fc3aab83dfa3b83c11d8f187f3L60-R61) [[3]](diffhunk://#diff-91586af16c8a3e1ddb8a2e48f65bdd7ff26709fc3aab83dfa3b83c11d8f187f3L105-R106) [[4]](diffhunk://#diff-91586af16c8a3e1ddb8a2e48f65bdd7ff26709fc3aab83dfa3b83c11d8f187f3L235-R235)

**Test Updates:**

* Updated all sequence route tests to expect JSON responses and check the appropriate fields (e.g., `response.get_json()["plantuml"]`). [[1]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL97-R97) [[2]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL120-R120) [[3]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL153-R153) [[4]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL179-R179) [[5]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL203-R203) [[6]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL229-R229) [[7]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL255-R255) [[8]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL313-R313) [[9]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL335-R335) [[10]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL359-R359) [[11]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL383-R383) [[12]](diffhunk://#diff-f467ad8454ffdb6bc237eefecfca1dc3ff13e28386127abfeb977cec5bf5bc2fL403-R403)