### PR TITLE
feat(sequence): add message edit/delete backend logic

### DIFF
--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -72,7 +72,8 @@
 │   ├── shared/             # Shared route tests (render, encode/decode)
 │   │   └── test_render.py
 │   ├── sequence/           # Sequence diagram tests
-│   │   └── test_participant.py
+│   │   ├── test_participant.py
+│   │   └── test_message.py
 │   └── e2e/                # Playwright end-to-end tests
 │       ├── conftest.py     # Live server fixture
 │       ├── test_app_loads.py  # App loads correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### External
 
+- Edit message text: right-click a message arrow/line to open Edit Message dialog
+- Delete message: right-click a message arrow/line to delete it
 - Visual hover-based "Add Message" interaction for sequence diagrams: hover near a participant lifeline to see an indicator box, right-click for "Add Message" context menu, then use ghost arrow preview to select destination
 - Self-messages supported (send message to same participant)
 - Add message context menu offers solid arrow (->) or dashed arrow (-->) choice
@@ -15,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Internal
 
+- Added backend logic for sequence message edit and delete (index_of_clicked_message, get_message_text, edit_message_text, delete_message)
 - Add message now uses y-based insertion to place new messages between existing ones based on click position
 - Added /getParticipantPositions backend endpoint for lifeline position and name extraction
 - Fixed reflected XSS in sequence routes by returning `jsonify` instead of raw strings

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -63,5 +63,7 @@ but adding them to the PlantUML code should still work.
   - Delete participant (cascades to messages)
 - Messages
   - Add message between participants (hover lifeline → right-click → ghost arrow → click destination)
+  - Edit message text (right-click message → Edit Message)
+  - Delete message (right-click message → Delete Message)
   - Self-messages supported (same participant as sender and receiver)
   - Messages inserted at correct vertical position between existing messages

--- a/docs/frontend_backend_contract.md
+++ b/docs/frontend_backend_contract.md
@@ -63,6 +63,9 @@ Used by: deleteActivity, detachActivity, breakActivity, checkBackward, addNoteAc
 - **deleteParticipant:** `{plantuml, svg, svgelement}`; returns `{"plantuml": updated_puml}`
 - **addMessage:** `{plantuml, svg, message, svgelement, firstcoordinates, secondcoordinates}` — coordinates are `[x, y]` arrays; y-coordinate determines insertion position between existing messages; returns `{"plantuml": updated_puml}`
 - **getParticipantPositions:** `{plantuml, svg}`; returns `{"positions": [{name, cx, yTop, yBottom}, ...]}` — called once per render to provide lifeline data for hover detection and ghost arrow
+- **getMessageText:** `{plantuml, svg, svgelement}`; returns `{"text": message_label}` — fetches current message label for the edit modal
+- **editMessageText:** `{plantuml, svg, svgelement, text}`; returns `{"plantuml": updated_puml}` — replaces the message label text
+- **deleteMessage:** `{plantuml, svg, svgelement}`; returns `{"plantuml": updated_puml}` — removes the message line from puml
 
 ## script.js Requests
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -119,3 +119,9 @@ All routes are organized into Blueprints: `shared_bp` (in `shared/routes.py`) fo
 - **POST /getParticipantName** — Input: `plantuml`, `svg`, `svgelement`. Returns: participant name string.
 - **POST /editParticipantName** — Input: `plantuml`, `svg`, `name`, `svgelement`. Returns: modified puml.
 - **POST /deleteParticipant** — Input: `plantuml`, `svg`, `svgelement`. Returns: modified puml.
+
+## Sequence Diagram (Messages)
+
+- **POST /getMessageText** — Input: `plantuml`, `svg`, `svgelement`. Returns: JSON `{"text": message_label}`.
+- **POST /editMessageText** — Input: `plantuml`, `svg`, `svgelement`, `text`. Returns: JSON `{"plantuml": modified_puml}`.
+- **POST /deleteMessage** — Input: `plantuml`, `svg`, `svgelement`. Returns: JSON `{"plantuml": modified_puml}`.

--- a/src/plantuml_gui/sequence/message.py
+++ b/src/plantuml_gui/sequence/message.py
@@ -24,6 +24,8 @@
 
 from typing import List
 
+from pyquery import PyQuery as Pq
+
 from .classes import Diagram, Message, Participant
 
 
@@ -79,4 +81,100 @@ def add_message(
     lines = puml.splitlines()
     insert_at = _find_insertion_index(diagram.messages, first_y, lines)
     lines.insert(insert_at, f"{sender.name} {arrow_type} {reciever.name}: {message}")
+    return "\n".join(lines)
+
+
+def _svg_element_matches(element: Pq, clicked: Pq) -> bool:
+    """Check if two SVG elements match by comparing tag and key attributes."""
+    tag = element[0].tag
+    clicked_tag = clicked[0].tag
+    if tag != clicked_tag:
+        return False
+    if tag == "polygon":
+        return element.attr("points") == clicked.attr("points")
+    if tag == "line":
+        return (
+            element.attr("x1") == clicked.attr("x1")
+            and element.attr("x2") == clicked.attr("x2")
+            and element.attr("y1") == clicked.attr("y1")
+            and element.attr("y2") == clicked.attr("y2")
+        )
+    if tag == "text":
+        return element.attr("x") == clicked.attr("x") and element.attr(
+            "y"
+        ) == clicked.attr("y")
+    return False
+
+
+def index_of_clicked_message(svg: str, svgelement: str) -> int:
+    """Find the 1-based index of the message containing the clicked SVG element.
+
+    Iterates SVG elements using the same grouping logic as Diagram._parse_messages,
+    checking if the clicked element matches any element in each message group.
+    """
+    d = Pq(svg)
+    clicked = Pq(svgelement)
+    elements = list(d("*").items())
+    i = 0
+    message_index = 0
+
+    while i < len(elements):
+        group = elements[i : i + 5]
+        tags = [el[0].tag for el in group]
+
+        if tags[:4] == ["polygon", "polygon", "line", "text"]:
+            message_index += 1
+            for el in group[:4]:
+                if _svg_element_matches(el, clicked):
+                    return message_index
+            i += 4
+        elif tags[:5] == ["line", "line", "line", "polygon", "text"]:
+            message_index += 1
+            for el in group[:5]:
+                if _svg_element_matches(el, clicked):
+                    return message_index
+            i += 5
+        elif tags[:3] == ["polygon", "line", "text"]:
+            message_index += 1
+            for el in group[:3]:
+                if _svg_element_matches(el, clicked):
+                    return message_index
+            i += 3
+        else:
+            i += 1
+
+    return -1
+
+
+def get_message_text(puml: str, svg: str, svgelement: str) -> str:
+    """Get the label text of the clicked message."""
+    diagram = Diagram.from_svg(svg, puml)
+    idx = index_of_clicked_message(svg, svgelement)
+    message = diagram.messages[idx - 1]
+    line = puml.splitlines()[message.index]
+    colon_pos = line.find(": ")
+    return line[colon_pos + 2 :] if colon_pos != -1 else ""
+
+
+def edit_message_text(puml: str, svg: str, svgelement: str, text: str) -> str:
+    """Edit the label text of the clicked message."""
+    diagram = Diagram.from_svg(svg, puml)
+    idx = index_of_clicked_message(svg, svgelement)
+    message = diagram.messages[idx - 1]
+    lines = puml.splitlines()
+    line = lines[message.index]
+    # Replace text after ": "
+    colon_pos = line.find(": ")
+    if colon_pos != -1:
+        lines[message.index] = line[: colon_pos + 2] + text
+    return "\n".join(lines)
+
+
+def delete_message(puml: str, svg: str, svgelement: str) -> str:
+    """Delete the clicked message."""
+    diagram = Diagram.from_svg(svg, puml)
+    idx = index_of_clicked_message(svg, svgelement)
+    message = diagram.messages[idx - 1]
+    lines = puml.splitlines()
+    del lines[message.index]
     return "\n".join(lines)

--- a/src/plantuml_gui/sequence/routes.py
+++ b/src/plantuml_gui/sequence/routes.py
@@ -24,7 +24,7 @@
 
 from flask import Blueprint, jsonify, request
 
-from .message import add_message
+from .message import add_message, delete_message, edit_message_text, get_message_text
 from .participant import (
     add_participant,
     delete_participant,
@@ -98,3 +98,31 @@ def getparticipantpositions():
     puml = data["plantuml"]
     svg = data["svg"]
     return jsonify({"positions": get_participant_positions(puml, svg)})
+
+
+@sequence_bp.route("/getMessageText", methods=["POST"])
+def getmessagetext():
+    data = request.get_json()
+    puml = data["plantuml"]
+    svg = data["svg"]
+    svgelement = data["svgelement"]
+    return jsonify({"text": get_message_text(puml, svg, svgelement)})
+
+
+@sequence_bp.route("/editMessageText", methods=["POST"])
+def editmessagetext():
+    data = request.get_json()
+    puml = data["plantuml"]
+    svg = data["svg"]
+    svgelement = data["svgelement"]
+    text = data["text"]
+    return jsonify({"plantuml": edit_message_text(puml, svg, svgelement, text)})
+
+
+@sequence_bp.route("/deleteMessage", methods=["POST"])
+def deletemessage():
+    data = request.get_json()
+    puml = data["plantuml"]
+    svg = data["svg"]
+    svgelement = data["svgelement"]
+    return jsonify({"plantuml": delete_message(puml, svg, svgelement)})

--- a/src/plantuml_gui/static/script.js
+++ b/src/plantuml_gui/static/script.js
@@ -518,7 +518,8 @@ function addSequenceEventListeners() {
     document.addEventListener('click', function(e) {
         var menuIds = [
             'sequence-menu',
-            'participant-menu'
+            'participant-menu',
+            'message-menu'
         ];
 
         menuIds.forEach(function(id) {

--- a/src/plantuml_gui/static/sequence-message.js
+++ b/src/plantuml_gui/static/sequence-message.js
@@ -244,21 +244,34 @@ function messageEventListeners() {
         var newmessage = $('#participant-message-text').val();
         try {
             const plantuml = trimlines(editor.session.getValue());
-            const response = await fetch("addMessage", {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    'plantuml': plantuml,
-                    'svg': svg.innerHTML,
-                    'message': newmessage,
-                    'svgelement': lastclickedsvgelement.outerHTML,
-                    'firstcoordinates': firstClickCoordinates,
-                    'secondcoordinates': secondClickCoordinates,
-                    'arrowtype': messageArrowType,
-                }),
-            });
+            let response;
+            if (messageEditMode) {
+                messageEditMode = false;
+                response = await fetch("editMessageText", {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        'plantuml': plantuml,
+                        'svg': svg.innerHTML,
+                        'svgelement': lastclickedsvgelement.outerHTML,
+                        'text': newmessage
+                    }),
+                });
+            } else {
+                response = await fetch("addMessage", {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        'plantuml': plantuml,
+                        'svg': svg.innerHTML,
+                        'message': newmessage,
+                        'svgelement': lastclickedsvgelement.outerHTML,
+                        'firstcoordinates': firstClickCoordinates,
+                        'secondcoordinates': secondClickCoordinates,
+                        'arrowtype': messageArrowType,
+                    }),
+                });
+            }
             const data = await response.json();
             setPuml(data.plantuml)
         } catch (error) {

--- a/src/plantuml_gui/static/sequence-operations.js
+++ b/src/plantuml_gui/static/sequence-operations.js
@@ -161,6 +161,8 @@ function participantEventListeners() {
 function setupParticipantHandlers(svgelements, svg, element) {
     for (let index = 0; index < svgelements.length; index++) {
         let svgelement = svgelements[index];
+        // Disable pointer events only on participant text (font-size 14) so clicks
+        // pass through to the rect beneath. Message text (font-size 13) stays clickable.
         if (svgelement.tagName.toLowerCase() === 'text' &&
             svgelement.getAttribute('font-size') === '14') {
             svgelement.style.pointerEvents = 'none';

--- a/src/plantuml_gui/static/sequence-operations.js
+++ b/src/plantuml_gui/static/sequence-operations.js
@@ -161,7 +161,8 @@ function participantEventListeners() {
 function setupParticipantHandlers(svgelements, svg, element) {
     for (let index = 0; index < svgelements.length; index++) {
         let svgelement = svgelements[index];
-        if (svgelement.tagName.toLowerCase() === 'text') {
+        if (svgelement.tagName.toLowerCase() === 'text' &&
+            svgelement.getAttribute('font-size') === '14') {
             svgelement.style.pointerEvents = 'none';
         }
 
@@ -222,6 +223,7 @@ function setupParticipantHandlers(svgelements, svg, element) {
 function sequenceEventListeners() {
     participantEventListeners();
     messageEventListeners();
+    messageOperationEventListeners();
 }
 
 // Called on every render when diagram type is sequence
@@ -241,6 +243,7 @@ async function setHandlersForSequenceDiagram(pumlcontent, element) {
         handleContextMenuBackground(svgContainer);
         setupLifelineInteraction(svgContainer);
         setupParticipantHandlers(svg.querySelectorAll('*'), svg, element);
+        setupMessageHandlers(svg.querySelectorAll('*'), svg);
 
         toggleLoadingOverlay();
     }).catch((error) => {
@@ -252,4 +255,102 @@ async function setHandlersForSequenceDiagram(pumlcontent, element) {
 function checkIfParticipant(svgelements, index) {
     return (svgelements[index].tagName.toLowerCase() === 'rect') &&
         (svgelements[index].getAttribute('style') == "stroke:#181818;stroke-width:0.5;");
+}
+
+// Identifies message elements (polygons and lines with stroke-width:1.0, and message text)
+function checkIfMessageElement(svgelement) {
+    const tag = svgelement.tagName.toLowerCase();
+    const style = svgelement.getAttribute('style') || '';
+    if ((tag === 'polygon' || tag === 'line') && style.includes('stroke-width:1.0')) {
+        return true;
+    }
+    if (tag === 'text' && svgelement.getAttribute('font-size') === '13') {
+        return true;
+    }
+    return false;
+}
+
+// --- Message element handlers (hover, contextmenu) ---
+
+function setupMessageHandlers(svgelements, svg) {
+    for (let index = 0; index < svgelements.length; index++) {
+        let svgelement = svgelements[index];
+        if (!checkIfMessageElement(svgelement)) continue;
+
+        svgelement.addEventListener('mouseover', function() {
+            svgelement.style.fontWeight = 'bold';
+            svgelement.style.strokeWidth = '2.0';
+        });
+
+        svgelement.addEventListener('mouseout', function() {
+            svgelement.style.fontWeight = '';
+            svgelement.style.strokeWidth = '';
+        });
+
+        svgelement.addEventListener('contextmenu', function(e) {
+            lastclickedsvgelement = svgelement;
+            e.preventDefault();
+            e.stopPropagation();
+            var contextMenu = document.getElementById('message-menu');
+            contextMenu.style.display = 'block';
+            contextMenu.style.left = e.pageX + 'px';
+            contextMenu.style.top = e.pageY + 'px';
+        });
+    }
+}
+
+// --- Message operation event listeners (edit, delete) ---
+
+let messageEditMode = false;
+
+function messageOperationEventListeners() {
+    // "Edit Message" context menu item
+    document.getElementById('editMessage').addEventListener('click', async () => {
+        const element = document.getElementById('colb');
+        const svg = element.querySelector('g');
+        try {
+            const plantuml = trimlines(editor.session.getValue());
+            const response = await fetch("getMessageText", {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    'plantuml': plantuml,
+                    'svg': svg.innerHTML,
+                    'svgelement': lastclickedsvgelement.outerHTML
+                })
+            });
+            const text = (await response.json()).text;
+            messageEditMode = true;
+            $('#participant-modalForm .modal-title').text('Edit Message');
+            $('#participant-message-text').val(text);
+            $('#participant-modalForm').modal('show');
+            $('#participant-modalForm').on('shown.bs.modal', function() {
+                $('#participant-message-text').trigger('focus');
+            });
+        } catch (error) {
+            displayErrorMessage(`Error with fetch API: ${error.message}`, error);
+        }
+    });
+
+    // "Delete Message" context menu item
+    document.getElementById('deleteMessage').addEventListener('click', async () => {
+        const element = document.getElementById('colb');
+        const svg = element.querySelector('g');
+        try {
+            const plantuml = trimlines(editor.session.getValue());
+            const response = await fetch("deleteMessage", {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    'plantuml': plantuml,
+                    'svg': svg.innerHTML,
+                    'svgelement': lastclickedsvgelement.outerHTML
+                })
+            });
+            const data = await response.json();
+            setPuml(data.plantuml);
+        } catch (error) {
+            displayErrorMessage(`Error with fetch API: ${error.message}`, error);
+        }
+    });
 }

--- a/src/plantuml_gui/templates/partials/sequence_menus.html
+++ b/src/plantuml_gui/templates/partials/sequence_menus.html
@@ -63,3 +63,9 @@
   <li><hr class="dropdown-divider"></li>
   <li><a class="dropdown-item" href="#" id="deleteParticipant">Delete Participant</a></li>
 </div>
+
+<div class="dropdown-menu" id="message-menu">
+  <li><a class="dropdown-item" href="#" id="editMessage">Edit Message</a></li>
+  <li><hr class="dropdown-divider"></li>
+  <li><a class="dropdown-item" href="#" id="deleteMessage">Delete Message</a></li>
+</div>

--- a/tests/sequence/test_message.py
+++ b/tests/sequence/test_message.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2025 Ericsson
+# Copyright (c) 2026 Ericsson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/sequence/test_message.py
+++ b/tests/sequence/test_message.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2025 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for sequence diagram message edit and delete operations."""
+
+import re
+
+from flask import json
+from plantuml_gui.sequence.message import (
+    delete_message,
+    edit_message_text,
+    get_message_text,
+    index_of_clicked_message,
+)
+from plantuml_gui.shared.render import _create_svg_from_uml
+from pyquery import PyQuery as Pq
+
+
+def extract_g_inner(svg_string):
+    """Extract the innerHTML of the <g> element from full SVG."""
+    match = re.search(r"<g>(.*?)</g>", svg_string, re.DOTALL)
+    if match:
+        return match.group(1)
+    return None
+
+
+def extract_message_element(svg_string, message_index=0, element_type="polygon"):
+    """Extract the outerHTML of an element from the nth message group.
+
+    element_type can be 'polygon', 'line', or 'text'.
+    Returns the first matching element in the message group.
+    """
+    d = Pq(svg_string)
+    elements = list(d("*").items())
+    i = 0
+    msg_count = 0
+
+    while i < len(elements):
+        group = elements[i : i + 5]
+        tags = [el[0].tag for el in group]
+
+        if tags[:4] == ["polygon", "polygon", "line", "text"]:
+            if msg_count == message_index:
+                for el in group[:4]:
+                    if el[0].tag == element_type:
+                        return str(el)
+            msg_count += 1
+            i += 4
+        elif tags[:5] == ["line", "line", "line", "polygon", "text"]:
+            if msg_count == message_index:
+                for el in group[:5]:
+                    if el[0].tag == element_type:
+                        return str(el)
+            msg_count += 1
+            i += 5
+        elif tags[:3] == ["polygon", "line", "text"]:
+            if msg_count == message_index:
+                for el in group[:3]:
+                    if el[0].tag == element_type:
+                        return str(el)
+            msg_count += 1
+            i += 3
+        else:
+            i += 1
+
+    return None
+
+
+class TestIndexOfClickedMessage:
+    def test_click_polygon_normal_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        assert svgelement is not None
+        assert index_of_clicked_message(svg, svgelement) == 1
+
+    def test_click_line_normal_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "line")
+        assert svgelement is not None
+        assert index_of_clicked_message(svg, svgelement) == 1
+
+    def test_click_text_normal_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "text")
+        assert svgelement is not None
+        assert index_of_clicked_message(svg, svgelement) == 1
+
+    def test_click_second_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello\nBob -> Alice: Bye\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 1, "polygon")
+        assert svgelement is not None
+        assert index_of_clicked_message(svg, svgelement) == 2
+
+    def test_click_self_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Alice: Think\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        assert svgelement is not None
+        assert index_of_clicked_message(svg, svgelement) == 1
+
+    def test_click_bidirectional_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice <-> Bob: Sync\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "line")
+        assert svgelement is not None
+        assert index_of_clicked_message(svg, svgelement) == 1
+
+
+class TestGetMessageText:
+    def test_normal_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello World\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        assert get_message_text(puml, svg, svgelement) == "Hello World"
+
+    def test_second_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: First\nBob -> Alice: Second\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 1, "polygon")
+        assert get_message_text(puml, svg, svgelement) == "Second"
+
+    def test_self_message(self):
+        puml = "@startuml\nparticipant Alice\nAlice -> Alice: Think\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        assert get_message_text(puml, svg, svgelement) == "Think"
+
+
+class TestEditMessageText:
+    def test_edit_normal_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        result = edit_message_text(puml, svg, svgelement, "Goodbye")
+        expected = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Goodbye\n@enduml"
+        assert result == expected
+
+    def test_edit_second_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: First\nBob -> Alice: Second\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 1, "polygon")
+        result = edit_message_text(puml, svg, svgelement, "Updated")
+        expected = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: First\nBob -> Alice: Updated\n@enduml"
+        assert result == expected
+
+    def test_edit_self_message(self):
+        puml = "@startuml\nparticipant Alice\nAlice -> Alice: Think\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        result = edit_message_text(puml, svg, svgelement, "Ponder")
+        expected = "@startuml\nparticipant Alice\nAlice -> Alice: Ponder\n@enduml"
+        assert result == expected
+
+    def test_edit_dashed_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice --> Bob: Dashed\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        result = edit_message_text(puml, svg, svgelement, "Still dashed")
+        expected = "@startuml\nparticipant Alice\nparticipant Bob\nAlice --> Bob: Still dashed\n@enduml"
+        assert result == expected
+
+
+class TestDeleteMessage:
+    def test_delete_single_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        result = delete_message(puml, svg, svgelement)
+        expected = "@startuml\nparticipant Alice\nparticipant Bob\n@enduml"
+        assert result == expected
+
+    def test_delete_first_of_two_messages(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: First\nBob -> Alice: Second\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        result = delete_message(puml, svg, svgelement)
+        expected = "@startuml\nparticipant Alice\nparticipant Bob\nBob -> Alice: Second\n@enduml"
+        assert result == expected
+
+    def test_delete_second_of_two_messages(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: First\nBob -> Alice: Second\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 1, "polygon")
+        result = delete_message(puml, svg, svgelement)
+        expected = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: First\n@enduml"
+        assert result == expected
+
+    def test_delete_self_message(self):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Alice: Think\nAlice -> Bob: Done\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        result = delete_message(puml, svg, svgelement)
+        expected = (
+            "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Done\n@enduml"
+        )
+        assert result == expected
+
+
+class TestMessageRoutes:
+    """Integration tests for message routes via Flask test client."""
+
+    def test_get_message_text(self, client):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello World\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        response = client.post(
+            "/getMessageText",
+            data=json.dumps({"plantuml": puml, "svg": svg, "svgelement": svgelement}),
+            content_type="application/json",
+        )
+        assert response.get_json()["text"] == "Hello World"
+
+    def test_edit_message_text(self, client):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        response = client.post(
+            "/editMessageText",
+            data=json.dumps(
+                {
+                    "plantuml": puml,
+                    "svg": svg,
+                    "svgelement": svgelement,
+                    "text": "Goodbye",
+                }
+            ),
+            content_type="application/json",
+        )
+        expected = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Goodbye\n@enduml"
+        assert response.get_json()["plantuml"] == expected
+
+    def test_delete_message(self, client):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello\nBob -> Alice: Bye\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "polygon")
+        response = client.post(
+            "/deleteMessage",
+            data=json.dumps({"plantuml": puml, "svg": svg, "svgelement": svgelement}),
+            content_type="application/json",
+        )
+        expected = (
+            "@startuml\nparticipant Alice\nparticipant Bob\nBob -> Alice: Bye\n@enduml"
+        )
+        assert response.get_json()["plantuml"] == expected
+
+    def test_delete_message_click_line(self, client):
+        puml = "@startuml\nparticipant Alice\nparticipant Bob\nAlice -> Bob: Hello\n@enduml"
+        svg = extract_g_inner(_create_svg_from_uml(puml))
+        svgelement = extract_message_element(svg, 0, "line")
+        response = client.post(
+            "/deleteMessage",
+            data=json.dumps({"plantuml": puml, "svg": svg, "svgelement": svgelement}),
+            content_type="application/json",
+        )
+        expected = "@startuml\nparticipant Alice\nparticipant Bob\n@enduml"
+        assert response.get_json()["plantuml"] == expected


### PR DESCRIPTION
This pull request adds support for editing and deleting sequence diagram messages through both the frontend UI and backend logic. Users can now right-click a message arrow or label to open a context menu with "Edit Message" and "Delete Message" options. The backend provides new endpoints and logic to identify, edit, and remove messages based on SVG elements. Documentation and tests have also been updated to reflect these new features.

**Frontend: Sequence Message Edit/Delete UI**
- Added a right-click context menu for messages with "Edit Message" and "Delete Message" actions, including hover highlighting and modal dialog for editing message text. [[1]](diffhunk://#diff-9c132cf3a22da61840ae49460872f7f3809d5ea9b63e9dae097cb11ec66106f7R259-R356) [[2]](diffhunk://#diff-756941d055cc1228a9a3f0ace1c082bb43b635b5738aef20d5b1a0f46b98b1ceR66-R71) [[3]](diffhunk://#diff-9c132cf3a22da61840ae49460872f7f3809d5ea9b63e9dae097cb11ec66106f7R226) [[4]](diffhunk://#diff-9c132cf3a22da61840ae49460872f7f3809d5ea9b63e9dae097cb11ec66106f7R246) [[5]](diffhunk://#diff-ec323750c99a2affbdba0b340a6e83ae3da6c6854c8b65235a713965de025aabL521-R522)
- Integrated message edit/delete operations into the main event handling flow and modal form logic. [[1]](diffhunk://#diff-0073d891e9dcf1a20a06cddba73d2558a302ab82c7e51abbfc5060764f9055ddL247-R263) [[2]](diffhunk://#diff-0073d891e9dcf1a20a06cddba73d2558a302ab82c7e51abbfc5060764f9055ddR274)

**Backend: Message Edit/Delete Endpoints and Logic**
- Implemented backend functions to identify a message by SVG element, retrieve its text, edit its text, and delete it from the PlantUML source. [[1]](diffhunk://#diff-618296c0d7648db66a5e1d665721d61516ce634a0a72806334b953c1cfbee667R85-R180) [[2]](diffhunk://#diff-618296c0d7648db66a5e1d665721d61516ce634a0a72806334b953c1cfbee667R27-R28)
- Added new Flask routes: `/getMessageText`, `/editMessageText`, and `/deleteMessage` to support these operations. [[1]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL27-R27) [[2]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dR101-R128)