### PR TITLE
Feature/participant activation bars

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -33,6 +33,7 @@ Enterprise developers and technical teams (primarily at Ericsson and similar com
 ### Sequence Diagrams
 - Participants (add left/right, rename, delete with cascade)
 - Add messages between participants
+- Activation bars (activate, deactivate, destroy participants)
 
 ## Business Objectives
 

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -17,6 +17,7 @@
 │   │   ├── classes.py      # Diagram, Participant, Message data classes
 │   │   ├── participant.py  # Participant logic (add, rename, delete, positions)
 │   │   ├── message.py      # Message logic (add message, y-based insertion)
+│   │   ├── activation.py   # Activation bar logic (activate + deactivate/destroy pair)
 │   │   ├── note.py         # Note logic (add, edit, delete notes)
 │   │   └── util.py         # Shared utilities (insertion index, note position extraction)
 │   ├── activity/           # Activity diagram package
@@ -75,7 +76,8 @@
 │   │   └── test_render.py
 │   ├── sequence/           # Sequence diagram tests
 │   │   ├── test_participant.py
-│   │   └── test_message.py
+│   │   ├── test_message.py
+│   │   └── test_activation.py
 │   └── e2e/                # Playwright end-to-end tests
 │       ├── conftest.py     # Live server fixture
 │       ├── test_app_loads.py  # App loads correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### External
 
+- Activation bars for sequence diagrams: right-click a lifeline → Activate, drag down to preview a ghost bar, then left-click and choose Deactivate or Destroy to end it (supports nested activations)
 - Deleting a participant now also deletes any notes referencing that participant
 - Fixed note left/right placement incorrectly attaching to a message at the same Y when the click was outside the message's horizontal span
 - Fixed note left/right near a self-message incorrectly using message-attached syntax instead of participant syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Internal
 
-- Added backend logic for sequence participant activation bars (add_activation) inserting a matched activate + deactivate/destroy pair by Y-position
-- Added /addActivation backend endpoint for sequence activation bars
+- Added backend logic for sequence participant activation bars (add_activation) inserting a matched activate + deactivate/destroy pair around the selected message lines
+- Added /addActivation and /getMessagePositions backend endpoints for sequence activation bars
+- Made sequence diagram parsing ignore activation-bar rects so message/participant parsing keeps working once a bar exists
+- Cache-busting hash now covers all static JS files, not just script.js
 - Added backend logic for sequence note add, edit, and delete (add_note, index_of_clicked_note, get_note_text, edit_note, delete_note)
 - Added /addNote, /getSeqNoteText, /editSeqNote, /deleteSeqNote backend endpoints for sequence notes
 - Added backend logic for sequence message edit and delete (index_of_clicked_message, get_message_text, edit_message_text, delete_message)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Internal
 
+- Added backend logic for sequence participant activation bars (add_activation) inserting a matched activate + deactivate/destroy pair by Y-position
+- Added /addActivation backend endpoint for sequence activation bars
 - Added backend logic for sequence note add, edit, and delete (add_note, index_of_clicked_note, get_note_text, edit_note, delete_note)
 - Added /addNote, /getSeqNoteText, /editSeqNote, /deleteSeqNote backend endpoints for sequence notes
 - Added backend logic for sequence message edit and delete (index_of_clicked_message, get_message_text, edit_message_text, delete_message)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### External
 
 - Activation bars for sequence diagrams: right-click a lifeline → Activate, drag down to preview a ghost bar, then left-click and choose Deactivate or Destroy to end it (supports nested activations)
+- Delete an activation bar: right-click the bar → Delete activation bar (removes the matched activate + deactivate/destroy pair)
 - Deleting a participant now also deletes any notes referencing that participant
 - Fixed note left/right placement incorrectly attaching to a message at the same Y when the click was outside the message's horizontal span
 - Fixed note left/right near a self-message incorrectly using message-attached syntax instead of participant syntax
@@ -24,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Added backend logic for sequence participant activation bars (add_activation) inserting a matched activate + deactivate/destroy pair around the selected message lines
 - Added /addActivation and /getMessagePositions backend endpoints for sequence activation bars
+- Added delete_activation logic and /deleteActivation endpoint to remove a clicked activation bar's matched activate + close pair (stack-paired, nesting-aware)
 - Made sequence diagram parsing ignore activation-bar rects so message/participant parsing keeps working once a bar exists
 - Cache-busting hash now covers all static JS files, not just script.js
 - Added backend logic for sequence note add, edit, and delete (add_note, index_of_clicked_note, get_note_text, edit_note, delete_note)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -78,3 +78,4 @@ but adding them to the PlantUML code should still work.
   - Deactivate ends the bar; Destroy ends the lifeline with an X
   - Nested activations supported (overlapping bars stack)
   - activate/deactivate/destroy lines inserted at the correct vertical position based on click Y-coordinate
+  - Delete an activation bar (right-click the bar → Delete activation bar); removes the matched activate + deactivate/destroy pair, leaving nested bars intact

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -72,3 +72,9 @@ but adding them to the PlantUML code should still work.
   - Edit note text (right-click note → Edit Note)
   - Delete note (right-click note → Delete Note)
   - Notes inserted at correct vertical position based on click Y-coordinate
+- Activation bars
+  - Activate a participant from the lifeline context menu (hover lifeline → right-click → Activate)
+  - Drag down to preview a ghost bar, then left-click and choose Deactivate or Destroy to end it
+  - Deactivate ends the bar; Destroy ends the lifeline with an X
+  - Nested activations supported (overlapping bars stack)
+  - activate/deactivate/destroy lines inserted at the correct vertical position based on click Y-coordinate

--- a/docs/frontend_backend_contract.md
+++ b/docs/frontend_backend_contract.md
@@ -71,7 +71,7 @@ Used by: deleteActivity, detachActivity, breakActivity, checkBackward, addNoteAc
 - **editSeqNote:** `{plantuml, svg, svgelement, text}`; returns `{"plantuml": updated_puml}` — replaces the note text
 - **deleteSeqNote:** `{plantuml, svg, svgelement}`; returns `{"plantuml": updated_puml}` — removes the note line from puml
 - **getMessagePositions:** `{plantuml, svg}`; returns `{"positions": [{cy, index, text}, ...]}` — one entry per message (SVG Y, puml line index, label). Fetched each render into `messagePositions`; the activation gesture snaps to the nearest message and sends its line index.
-- **addActivation:** `{plantuml, participant, startMessageIndex, endMessageIndex, endType}`; returns `{"plantuml": updated_puml}` — inserts a matched `activate` line before the message at `startMessageIndex` and a closing `deactivate`/`destroy` line after the message at `endMessageIndex`; `endType` is 'deactivate' or 'destroy' (defaults to 'deactivate')
+- **addActivation:** `{plantuml, participant, startMessageIndex, endMessageIndex, endType}`; returns `{"plantuml": updated_puml}` — inserts a matched `activate` line after the message at `startMessageIndex` and a closing `deactivate`/`destroy` line after the message at `endMessageIndex`; `endType` is 'deactivate' or 'destroy' (defaults to 'deactivate')
 - **deleteActivation:** `{plantuml, svg, svgelement}`; returns `{"plantuml": updated_puml}` — `svgelement` is the right-clicked activation-bar rect; removes that bar's `activate` line and its paired `deactivate`/`destroy` line (handles nested bars)
 
 ## script.js Requests

--- a/docs/frontend_backend_contract.md
+++ b/docs/frontend_backend_contract.md
@@ -70,7 +70,8 @@ Used by: deleteActivity, detachActivity, breakActivity, checkBackward, addNoteAc
 - **getSeqNoteText:** `{plantuml, svg, svgelement}`; returns `{"text": note_text}` — fetches current note text for the edit modal
 - **editSeqNote:** `{plantuml, svg, svgelement, text}`; returns `{"plantuml": updated_puml}` — replaces the note text
 - **deleteSeqNote:** `{plantuml, svg, svgelement}`; returns `{"plantuml": updated_puml}` — removes the note line from puml
-- **addActivation:** `{plantuml, svg, participant, startY, endY, endType}`; returns `{"plantuml": updated_puml}` — inserts a matched `activate` line at `startY` and a closing `deactivate`/`destroy` line at `endY` for the participant; `endType` is 'deactivate' or 'destroy' (defaults to 'deactivate')
+- **getMessagePositions:** `{plantuml, svg}`; returns `{"positions": [{cy, index, text}, ...]}` — one entry per message (SVG Y, puml line index, label). Fetched each render into `messagePositions`; the activation gesture snaps to the nearest message and sends its line index.
+- **addActivation:** `{plantuml, participant, startMessageIndex, endMessageIndex, endType}`; returns `{"plantuml": updated_puml}` — inserts a matched `activate` line before the message at `startMessageIndex` and a closing `deactivate`/`destroy` line after the message at `endMessageIndex`; `endType` is 'deactivate' or 'destroy' (defaults to 'deactivate')
 
 ## script.js Requests
 

--- a/docs/frontend_backend_contract.md
+++ b/docs/frontend_backend_contract.md
@@ -70,6 +70,7 @@ Used by: deleteActivity, detachActivity, breakActivity, checkBackward, addNoteAc
 - **getSeqNoteText:** `{plantuml, svg, svgelement}`; returns `{"text": note_text}` — fetches current note text for the edit modal
 - **editSeqNote:** `{plantuml, svg, svgelement, text}`; returns `{"plantuml": updated_puml}` — replaces the note text
 - **deleteSeqNote:** `{plantuml, svg, svgelement}`; returns `{"plantuml": updated_puml}` — removes the note line from puml
+- **addActivation:** `{plantuml, svg, participant, startY, endY, endType}`; returns `{"plantuml": updated_puml}` — inserts a matched `activate` line at `startY` and a closing `deactivate`/`destroy` line at `endY` for the participant; `endType` is 'deactivate' or 'destroy' (defaults to 'deactivate')
 
 ## script.js Requests
 

--- a/docs/frontend_backend_contract.md
+++ b/docs/frontend_backend_contract.md
@@ -72,6 +72,7 @@ Used by: deleteActivity, detachActivity, breakActivity, checkBackward, addNoteAc
 - **deleteSeqNote:** `{plantuml, svg, svgelement}`; returns `{"plantuml": updated_puml}` — removes the note line from puml
 - **getMessagePositions:** `{plantuml, svg}`; returns `{"positions": [{cy, index, text}, ...]}` — one entry per message (SVG Y, puml line index, label). Fetched each render into `messagePositions`; the activation gesture snaps to the nearest message and sends its line index.
 - **addActivation:** `{plantuml, participant, startMessageIndex, endMessageIndex, endType}`; returns `{"plantuml": updated_puml}` — inserts a matched `activate` line before the message at `startMessageIndex` and a closing `deactivate`/`destroy` line after the message at `endMessageIndex`; `endType` is 'deactivate' or 'destroy' (defaults to 'deactivate')
+- **deleteActivation:** `{plantuml, svg, svgelement}`; returns `{"plantuml": updated_puml}` — `svgelement` is the right-clicked activation-bar rect; removes that bar's `activate` line and its paired `deactivate`/`destroy` line (handles nested bars)
 
 ## script.js Requests
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -126,6 +126,10 @@ All routes are organized into Blueprints: `shared_bp` (in `shared/routes.py`) fo
 - **POST /editMessageText** — Input: `plantuml`, `svg`, `svgelement`, `text`. Returns: JSON `{"plantuml": modified_puml}`.
 - **POST /deleteMessage** — Input: `plantuml`, `svg`, `svgelement`. Returns: JSON `{"plantuml": modified_puml}`.
 
+## Sequence Diagram (Activation Bars)
+
+- **POST /addActivation** — Input: `plantuml`, `svg`, `participant`, `startY`, `endY`, `endType` ('deactivate'/'destroy'). Returns: JSON `{"plantuml": modified_puml}`. Inserts a matched `activate <participant>` line at the `startY` position and a closing `deactivate <participant>` (or `destroy <participant>`) line at the `endY` position. `endType` defaults to 'deactivate' for any value other than 'destroy'.
+
 ## Sequence Diagram (Notes)
 
 - **POST /addNote** — Input: `plantuml`, `svg`, `participant`, `placement` ('over'/'left'/'right'/'spanning'), `text`, `yPosition`, optional `secondParticipant`. Returns: JSON `{"plantuml": modified_puml}`. Y-coordinate determines insertion position.

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -129,7 +129,7 @@ All routes are organized into Blueprints: `shared_bp` (in `shared/routes.py`) fo
 
 ## Sequence Diagram (Activation Bars)
 
-- **POST /addActivation** — Input: `plantuml`, `participant`, `startMessageIndex` (int), `endMessageIndex` (int), `endType` ('deactivate'/'destroy'). Returns: JSON `{"plantuml": modified_puml}`. Inserts a matched `activate <participant>` line just before the message at `startMessageIndex` and a closing `deactivate <participant>` (or `destroy <participant>`) line just after the message at `endMessageIndex`. The indexes are puml line numbers; the frontend obtains them from `/getMessagePositions`. `endType` defaults to 'deactivate' for any value other than 'destroy'.
+- **POST /addActivation** — Input: `plantuml`, `participant`, `startMessageIndex` (int), `endMessageIndex` (int), `endType` ('deactivate'/'destroy'). Returns: JSON `{"plantuml": modified_puml}`. Inserts a matched `activate <participant>` line just after the message at `startMessageIndex` and a closing `deactivate <participant>` (or `destroy <participant>`) line just after the message at `endMessageIndex`. The indexes are puml line numbers; the frontend obtains them from `/getMessagePositions`. `endType` defaults to 'deactivate' for any value other than 'destroy'.
 - **POST /deleteActivation** — Input: `plantuml`, `svg`, `svgelement` (the clicked activation-bar rect). Returns: JSON `{"plantuml": modified_puml}`. Matches the clicked bar to its `activate`/`deactivate`(or `destroy`) pair — by participant, the message above the `activate` line, and nesting level — and removes both lines, leaving nested or sibling bars intact.
 
 ## Sequence Diagram (Notes)

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -130,6 +130,7 @@ All routes are organized into Blueprints: `shared_bp` (in `shared/routes.py`) fo
 ## Sequence Diagram (Activation Bars)
 
 - **POST /addActivation** — Input: `plantuml`, `participant`, `startMessageIndex` (int), `endMessageIndex` (int), `endType` ('deactivate'/'destroy'). Returns: JSON `{"plantuml": modified_puml}`. Inserts a matched `activate <participant>` line just before the message at `startMessageIndex` and a closing `deactivate <participant>` (or `destroy <participant>`) line just after the message at `endMessageIndex`. The indexes are puml line numbers; the frontend obtains them from `/getMessagePositions`. `endType` defaults to 'deactivate' for any value other than 'destroy'.
+- **POST /deleteActivation** — Input: `plantuml`, `svg`, `svgelement` (the clicked activation-bar rect). Returns: JSON `{"plantuml": modified_puml}`. Matches the clicked bar to its `activate`/`deactivate`(or `destroy`) pair — by participant, the message above the `activate` line, and nesting level — and removes both lines, leaving nested or sibling bars intact.
 
 ## Sequence Diagram (Notes)
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -125,10 +125,11 @@ All routes are organized into Blueprints: `shared_bp` (in `shared/routes.py`) fo
 - **POST /getMessageText** — Input: `plantuml`, `svg`, `svgelement`. Returns: JSON `{"text": message_label}`.
 - **POST /editMessageText** — Input: `plantuml`, `svg`, `svgelement`, `text`. Returns: JSON `{"plantuml": modified_puml}`.
 - **POST /deleteMessage** — Input: `plantuml`, `svg`, `svgelement`. Returns: JSON `{"plantuml": modified_puml}`.
+- **POST /getMessagePositions** — Input: `plantuml`, `svg`. Returns: JSON `{"positions": [{cy, index, text}, ...]}` — one entry per message with its SVG Y-coordinate, puml line index, and label. Called once per render so the frontend can snap activation-bar endpoints to the nearest message.
 
 ## Sequence Diagram (Activation Bars)
 
-- **POST /addActivation** — Input: `plantuml`, `svg`, `participant`, `startY`, `endY`, `endType` ('deactivate'/'destroy'). Returns: JSON `{"plantuml": modified_puml}`. Inserts a matched `activate <participant>` line at the `startY` position and a closing `deactivate <participant>` (or `destroy <participant>`) line at the `endY` position. `endType` defaults to 'deactivate' for any value other than 'destroy'.
+- **POST /addActivation** — Input: `plantuml`, `participant`, `startMessageIndex` (int), `endMessageIndex` (int), `endType` ('deactivate'/'destroy'). Returns: JSON `{"plantuml": modified_puml}`. Inserts a matched `activate <participant>` line just before the message at `startMessageIndex` and a closing `deactivate <participant>` (or `destroy <participant>`) line just after the message at `endMessageIndex`. The indexes are puml line numbers; the frontend obtains them from `/getMessagePositions`. `endType` defaults to 'deactivate' for any value other than 'destroy'.
 
 ## Sequence Diagram (Notes)
 

--- a/src/plantuml_gui/sequence/activation.py
+++ b/src/plantuml_gui/sequence/activation.py
@@ -25,41 +25,40 @@
 """Activation bar logic for sequence diagrams.
 
 A single user gesture creates one balanced activation bar for one participant:
-an ``activate <P>`` line at the start-Y position and a closing ``deactivate <P>``
-or ``destroy <P>`` line at the end-Y position. Because the gesture always starts
-by activating and inserts a matched pair, a participant can never be deactivated
-without first being activated.
+an ``activate <P>`` line before the message at ``start_index`` and a closing
+``deactivate <P>`` or ``destroy <P>`` line after the message at ``end_index``.
+Because the gesture always starts by activating and inserts a matched pair, a
+participant can never be deactivated without first being activated.
 """
-
-from .classes import Diagram
-from .util import find_insertion_index
 
 
 def add_activation(
     puml: str,
-    svg: str,
     participant_name: str,
-    start_y: float,
-    end_y: float,
+    start_index: int,
+    end_index: int,
     end_type: str,
 ) -> str:
-    """Insert a matched activate + close pair for a participant by Y-position.
+    """Insert a matched activate + close pair for a participant by line index.
 
-    ``end_type`` is ``"destroy"`` to end the lifeline with an X, otherwise the
-    bar is closed with ``deactivate``. The closing line is inserted first (it
-    sits at a greater-or-equal line index), then the ``activate`` line, so
-    source order always has ``activate`` before its close and the index of the
-    start insertion stays valid.
+    ``start_index`` and ``end_index`` are the puml line numbers of the messages
+    nearest to where the user started and ended the gesture. The ``activate``
+    line is inserted just *after* the start message and the closing line just
+    *after* the end message, so both anchor below their nearest message. The bar
+    therefore covers the messages following the start message up to and
+    including the end message. ``end_type`` is ``"destroy"`` to end the lifeline
+    with an X, otherwise the bar is closed with ``deactivate``.
+
+    The closing line is inserted first (it sits at a greater-or-equal line
+    index), then the ``activate`` line, so the start insertion index stays valid.
     """
     keyword = "destroy" if end_type == "destroy" else "deactivate"
 
-    diagram = Diagram.from_svg(svg, puml)
     lines = puml.splitlines()
 
-    start_index = find_insertion_index(diagram.messages, svg, puml, start_y, lines)
-    end_index = find_insertion_index(diagram.messages, svg, puml, end_y, lines)
-
-    # Insert the closing line first so start_index remains valid afterwards.
-    lines.insert(end_index, f"{keyword} {participant_name}")
-    lines.insert(start_index, f"activate {participant_name}")
+    # Insert the closing line after the end message, then the opening line after
+    # the start message. Inserting the (lower) end line first keeps the start
+    # insertion index valid.
+    lines.insert(end_index + 1, f"{keyword} {participant_name}")
+    lines.insert(start_index + 1, f"activate {participant_name}")
     return "\n".join(lines)

--- a/src/plantuml_gui/sequence/activation.py
+++ b/src/plantuml_gui/sequence/activation.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2026 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Activation bar logic for sequence diagrams.
+
+A single user gesture creates one balanced activation bar for one participant:
+an ``activate <P>`` line at the start-Y position and a closing ``deactivate <P>``
+or ``destroy <P>`` line at the end-Y position. Because the gesture always starts
+by activating and inserts a matched pair, a participant can never be deactivated
+without first being activated.
+"""
+
+from .classes import Diagram
+from .util import find_insertion_index
+
+
+def add_activation(
+    puml: str,
+    svg: str,
+    participant_name: str,
+    start_y: float,
+    end_y: float,
+    end_type: str,
+) -> str:
+    """Insert a matched activate + close pair for a participant by Y-position.
+
+    ``end_type`` is ``"destroy"`` to end the lifeline with an X, otherwise the
+    bar is closed with ``deactivate``. The closing line is inserted first (it
+    sits at a greater-or-equal line index), then the ``activate`` line, so
+    source order always has ``activate`` before its close and the index of the
+    start insertion stays valid.
+    """
+    keyword = "destroy" if end_type == "destroy" else "deactivate"
+
+    diagram = Diagram.from_svg(svg, puml)
+    lines = puml.splitlines()
+
+    start_index = find_insertion_index(diagram.messages, svg, puml, start_y, lines)
+    end_index = find_insertion_index(diagram.messages, svg, puml, end_y, lines)
+
+    # Insert the closing line first so start_index remains valid afterwards.
+    lines.insert(end_index, f"{keyword} {participant_name}")
+    lines.insert(start_index, f"activate {participant_name}")
+    return "\n".join(lines)

--- a/src/plantuml_gui/sequence/activation.py
+++ b/src/plantuml_gui/sequence/activation.py
@@ -31,6 +31,12 @@ Because the gesture always starts by activating and inserts a matched pair, a
 participant can never be deactivated without first being activated.
 """
 
+from typing import List, Optional, Tuple
+
+from pyquery import PyQuery as Pq
+
+from .classes import Diagram, Message, Participant
+
 
 def add_activation(
     puml: str,
@@ -61,4 +67,88 @@ def add_activation(
     # insertion index valid.
     lines.insert(end_index + 1, f"{keyword} {participant_name}")
     lines.insert(start_index + 1, f"activate {participant_name}")
+    return "\n".join(lines)
+
+
+def _activation_pairs(
+    lines: List[str], participant_name: str
+) -> List[Tuple[int, int, int]]:
+    """Pair each ``activate`` with its closing ``deactivate``/``destroy`` line.
+
+    Returns ``(activate_line, close_line, level)`` tuples for the participant,
+    resolved with a stack so nested bars pair correctly. ``level`` is the
+    nesting depth (0 = outermost), which mirrors how PlantUML offsets nested
+    bars horizontally.
+    """
+    activate_text = f"activate {participant_name}"
+    close_texts = (f"deactivate {participant_name}", f"destroy {participant_name}")
+    stack: List[int] = []
+    pairs: List[Tuple[int, int, int]] = []
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == activate_text:
+            stack.append(index)
+        elif stripped in close_texts and stack:
+            start = stack.pop()
+            pairs.append((start, index, len(stack)))
+    return pairs
+
+
+def _message_cy_above(messages: List[Message], line_index: int) -> Optional[float]:
+    """Return the cy of the message on the closest line above ``line_index``."""
+    above = [m for m in messages if m.index < line_index]
+    if not above:
+        return None
+    return max(above, key=lambda m: m.index).cy
+
+
+def _nearest_participant(
+    participants: List[Participant], cx: float
+) -> Optional[Participant]:
+    if not participants:
+        return None
+    return min(participants, key=lambda p: abs(p.cx - cx))
+
+
+def delete_activation(puml: str, svg: str, svgelement: str) -> str:
+    """Remove the activation bar matching the clicked rect and its closing line.
+
+    The clicked rect identifies a bar by its lifeline (x), top (y) and nesting
+    offset. Each puml ``activate``/close pair has a predictable geometry — its
+    top aligns with the message just above the ``activate`` line and its centre
+    is offset right by the nesting level — so the clicked rect is matched to the
+    nearest pair, and only that pair's two lines are removed.
+    """
+    clicked = Pq(svgelement)
+    x = float(clicked.attr("x"))
+    width = float(clicked.attr("width"))
+    clicked_top = float(clicked.attr("y"))
+    clicked_cx = x + width / 2
+    level_offset = width / 2
+
+    diagram = Diagram.from_svg(svg, puml)
+    participant = _nearest_participant(diagram.participants, clicked_cx)
+    if participant is None:
+        return puml
+
+    lines = puml.splitlines()
+    best: Optional[Tuple[int, int]] = None
+    best_distance = float("inf")
+    for activate_line, close_line, level in _activation_pairs(lines, participant.name):
+        expected_top = _message_cy_above(diagram.messages, activate_line)
+        if expected_top is None:
+            continue
+        expected_cx = participant.cx + level * level_offset
+        distance = abs(expected_top - clicked_top) + abs(expected_cx - clicked_cx)
+        if distance < best_distance:
+            best_distance = distance
+            best = (activate_line, close_line)
+
+    if best is None:
+        return puml
+
+    activate_line, close_line = best
+    # Delete the (higher-index) close line first so activate_line stays valid.
+    del lines[close_line]
+    del lines[activate_line]
     return "\n".join(lines)

--- a/src/plantuml_gui/sequence/classes.py
+++ b/src/plantuml_gui/sequence/classes.py
@@ -27,6 +27,31 @@ from typing import Dict, List
 
 from pyquery import PyQuery as Pq  # pragma: no cover
 
+# Style PlantUML gives participant header rects. Used to distinguish them from
+# other rects in the SVG (e.g. activation bars, which use stroke-width:1.0).
+# Matches the identification used by the frontend's checkIfParticipant.
+PARTICIPANT_RECT_STYLE = "stroke:#181818;stroke-width:0.5;"
+
+
+def is_participant_rect(rect: Pq) -> bool:
+    """Return True if an SVG rect is a participant header (not an activation bar)."""
+    return (rect.attr("style") or "") == PARTICIPANT_RECT_STYLE
+
+
+def _participant_at(participants: List["Participant"], x: float) -> "Participant":
+    """Return the participant whose header spans ``x``, else the closest by cx.
+
+    Falling back to the nearest participant keeps message parsing robust when an
+    arrow endpoint lands slightly outside a header box (for example when an
+    activation bar shifts where the arrow meets the lifeline), instead of
+    raising and turning the whole request into a 500. Callers only parse
+    messages after participants are parsed, so the list is non-empty here.
+    """
+    for participant in participants:
+        if participant.contains_x(x):
+            return participant
+    return min(participants, key=lambda p: abs(p.cx - x))
+
 
 @dataclass
 class Participant:
@@ -87,8 +112,8 @@ class Message:
 
         message = text.text()
 
-        from_participant = next((p for p in participants if p.contains_x(start_x)))
-        to_participant = next((p for p in participants if p.contains_x(arrow_x)))
+        from_participant = _participant_at(participants, start_x)
+        to_participant = _participant_at(participants, arrow_x)
 
         return cls(from_participant, to_participant, message, cy)
 
@@ -106,8 +131,8 @@ class Message:
         start_x = x1
         to_x = x2
 
-        from_participant = next((p for p in participants if p.contains_x(start_x)))
-        to_participant = next((p for p in participants if p.contains_x(to_x)))
+        from_participant = _participant_at(participants, start_x)
+        to_participant = _participant_at(participants, to_x)
 
         return cls(
             from_participant=from_participant,
@@ -134,7 +159,7 @@ class Message:
 
         message = text.text()
 
-        from_participant = next((p for p in participants if p.contains_x(start_x)))
+        from_participant = _participant_at(participants, start_x)
 
         return cls(
             from_participant=from_participant,
@@ -164,6 +189,8 @@ class Diagram:
         unique_participants: Dict[int, Participant] = {}
 
         for rect in svg("rect").items():
+            if not is_participant_rect(rect):
+                continue  # skip activation bars and other non-participant rects
             text = rect.next()
             participant = Participant.from_svg(rect, text)
 

--- a/src/plantuml_gui/sequence/message.py
+++ b/src/plantuml_gui/sequence/message.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List
+from typing import Dict, List
 
 from pyquery import PyQuery as Pq
 
@@ -162,3 +162,21 @@ def delete_message(puml: str, svg: str, svgelement: str) -> str:
     lines = puml.splitlines()
     del lines[message.index]
     return "\n".join(lines)
+
+
+def get_message_positions(puml: str, svg: str) -> List[Dict[str, object]]:
+    """Return message positions for frontend snapping during activation-bar gestures.
+
+    Each entry contains the SVG Y-coordinate (``cy``), the puml line index
+    (``index``), and the message label text (``text``).  The frontend stores
+    these as ``messagePositions`` and uses them to snap the start/end of an
+    activation bar to the nearest message line.
+    """
+    diagram = Diagram.from_svg(svg, puml)
+    lines = puml.splitlines()
+    positions = []
+    for msg in diagram.messages:
+        colon_pos = lines[msg.index].find(": ")
+        text = lines[msg.index][colon_pos + 2 :] if colon_pos != -1 else ""
+        positions.append({"cy": msg.cy, "index": msg.index, "text": text})
+    return positions

--- a/src/plantuml_gui/sequence/participant.py
+++ b/src/plantuml_gui/sequence/participant.py
@@ -28,7 +28,7 @@ from typing import Dict, List
 
 from pyquery import PyQuery as Pq
 
-from .classes import Diagram
+from .classes import Diagram, is_participant_rect
 
 
 def index_of_clicked_participant(svg: str, svgelement: str) -> int:
@@ -50,6 +50,8 @@ def index_of_clicked_participant(svg: str, svgelement: str) -> int:
     seen_cx: set[float] = set()
     count = 0
     for rect in d("rect").items():
+        if not is_participant_rect(rect):
+            continue  # skip activation bars and other non-participant rects
         cx = float(rect.attr("x")) + float(rect.attr("width")) / 2
         if cx not in seen_cx:
             seen_cx.add(cx)

--- a/src/plantuml_gui/sequence/routes.py
+++ b/src/plantuml_gui/sequence/routes.py
@@ -25,7 +25,13 @@
 from flask import Blueprint, jsonify, request
 
 from .activation import add_activation
-from .message import add_message, delete_message, edit_message_text, get_message_text
+from .message import (
+    add_message,
+    delete_message,
+    edit_message_text,
+    get_message_positions,
+    get_message_text,
+)
 from .note import add_note, delete_note, edit_note, get_note_text
 from .participant import (
     add_participant,
@@ -70,13 +76,16 @@ def addmessage():
 def addactivation():
     data = request.get_json()
     puml = data["plantuml"]
-    svg = data["svg"]
     participant = data["participant"]
-    start_y = data["startY"]
-    end_y = data["endY"]
+    start_index = data["startMessageIndex"]
+    end_index = data["endMessageIndex"]
     end_type = data["endType"]
     return jsonify(
-        {"plantuml": add_activation(puml, svg, participant, start_y, end_y, end_type)}
+        {
+            "plantuml": add_activation(
+                puml, participant, start_index, end_index, end_type
+            )
+        }
     )
 
 
@@ -142,6 +151,14 @@ def deletemessage():
     svg = data["svg"]
     svgelement = data["svgelement"]
     return jsonify({"plantuml": delete_message(puml, svg, svgelement)})
+
+
+@sequence_bp.route("/getMessagePositions", methods=["POST"])
+def getmessagepositions():
+    data = request.get_json()
+    puml = data["plantuml"]
+    svg = data["svg"]
+    return jsonify({"positions": get_message_positions(puml, svg)})
 
 
 @sequence_bp.route("/addNote", methods=["POST"])

--- a/src/plantuml_gui/sequence/routes.py
+++ b/src/plantuml_gui/sequence/routes.py
@@ -24,6 +24,7 @@
 
 from flask import Blueprint, jsonify, request
 
+from .activation import add_activation
 from .message import add_message, delete_message, edit_message_text, get_message_text
 from .note import add_note, delete_note, edit_note, get_note_text
 from .participant import (
@@ -62,6 +63,20 @@ def addmessage():
                 puml, svg, message, firstcoordinates, secondcoordinates, arrow_type
             )
         }
+    )
+
+
+@sequence_bp.route("/addActivation", methods=["POST"])
+def addactivation():
+    data = request.get_json()
+    puml = data["plantuml"]
+    svg = data["svg"]
+    participant = data["participant"]
+    start_y = data["startY"]
+    end_y = data["endY"]
+    end_type = data["endType"]
+    return jsonify(
+        {"plantuml": add_activation(puml, svg, participant, start_y, end_y, end_type)}
     )
 
 

--- a/src/plantuml_gui/sequence/routes.py
+++ b/src/plantuml_gui/sequence/routes.py
@@ -24,7 +24,7 @@
 
 from flask import Blueprint, jsonify, request
 
-from .activation import add_activation
+from .activation import add_activation, delete_activation
 from .message import (
     add_message,
     delete_message,
@@ -87,6 +87,15 @@ def addactivation():
             )
         }
     )
+
+
+@sequence_bp.route("/deleteActivation", methods=["POST"])
+def deleteactivation():
+    data = request.get_json()
+    puml = data["plantuml"]
+    svg = data["svg"]
+    svgelement = data["svgelement"]
+    return jsonify({"plantuml": delete_activation(puml, svg, svgelement)})
 
 
 @sequence_bp.route("/getParticipantName", methods=["POST"])

--- a/src/plantuml_gui/shared/routes.py
+++ b/src/plantuml_gui/shared/routes.py
@@ -41,19 +41,26 @@ shared_bp = Blueprint(
 )
 
 
-def generate_file_hash(file_path):
-    with open(file_path, "rb") as file:
-        file_content = file.read()
-        return hashlib.sha256(file_content).hexdigest()[:8]
+def generate_static_js_hash():
+    """Hash all static JS files so editing any of them busts the browser cache.
 
-
-SCRIPT_PATH = os.path.join(shared_bp.static_folder, "script.js")
+    The template applies a single ?v=<hash> query string to every script tag,
+    so the hash must cover every served JS file (not just script.js) to avoid
+    browsers serving a stale module after it changes.
+    """
+    static_dir = shared_bp.static_folder
+    hasher = hashlib.sha256()
+    for name in sorted(os.listdir(static_dir)):
+        if name.endswith(".js"):
+            with open(os.path.join(static_dir, name), "rb") as file:
+                hasher.update(file.read())
+    return hasher.hexdigest()[:8]
 
 
 @shared_bp.route("/")
 def home():
-    # generate hash for script.js
-    file_hash = generate_file_hash(SCRIPT_PATH)
+    # Cache-busting hash covering all static JS files.
+    file_hash = generate_static_js_hash()
     # pass hash to the template
     return render_template(
         "index.html", script_hash=file_hash, version=__version__

--- a/src/plantuml_gui/shared/routes.py
+++ b/src/plantuml_gui/shared/routes.py
@@ -25,6 +25,7 @@
 import hashlib
 import io
 import os
+from functools import lru_cache
 
 from flask import Blueprint, jsonify, render_template, request, send_file
 
@@ -41,12 +42,15 @@ shared_bp = Blueprint(
 )
 
 
+@lru_cache(maxsize=1)
 def generate_static_js_hash():
     """Hash all static JS files so editing any of them busts the browser cache.
 
     The template applies a single ?v=<hash> query string to every script tag,
     so the hash must cover every served JS file (not just script.js) to avoid
-    browsers serving a stale module after it changes.
+    browsers serving a stale module after it changes. Cached for the life of
+    the process: static files don't change without a restart, so re-reading
+    and re-hashing every JS file on every request to / is wasted work.
     """
     static_dir = shared_bp.static_folder
     hasher = hashlib.sha256()

--- a/src/plantuml_gui/static/script.js
+++ b/src/plantuml_gui/static/script.js
@@ -521,7 +521,8 @@ function addSequenceEventListeners() {
             'participant-menu',
             'message-menu',
             'seq-note-placement-menu',
-            'seq-note-menu'
+            'seq-note-menu',
+            'activation-end-menu'
         ];
 
         menuIds.forEach(function(id) {

--- a/src/plantuml_gui/static/sequence-activation.js
+++ b/src/plantuml_gui/static/sequence-activation.js
@@ -1,16 +1,71 @@
 // State for the add-activation interaction flow
 let isAddActivationActive = false;
-let activationOrigin = null; // {cx, name, startY}
-let activationEndY = null;
+let activationOrigin = null; // {cx, name, startMessageIndex, startCy}
+let activationEndMessage = null; // {index, cy}
+
+// Message positions fetched from backend (refreshed each render)
+let messagePositions = []; // [{cy, index, text}, ...]
 
 // Reusable ghost bar overlay element (created once, moved on each frame)
 let ghostActivationBar = null;
 
 const ACTIVATION_BAR_WIDTH = 10;
 
+// --- Message position management ---
+
+async function fetchMessagePositions() {
+    const element = document.getElementById('colb');
+    const svg = element.querySelector('g');
+    if (!svg) {
+        messagePositions = [];
+        return;
+    }
+    try {
+        const plantuml = trimlines(editor.session.getValue());
+        const response = await fetch("getMessagePositions", {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({plantuml: plantuml, svg: svg.innerHTML})
+        });
+        const data = await response.json();
+        messagePositions = data.positions;
+    } catch (error) {
+        messagePositions = [];
+    }
+}
+
+function findNearestMessage(y) {
+    if (messagePositions.length === 0) return null;
+    let nearest = messagePositions[0];
+    let minDist = Math.abs(y - nearest.cy);
+    for (let i = 1; i < messagePositions.length; i++) {
+        const dist = Math.abs(y - messagePositions[i].cy);
+        if (dist < minDist) {
+            minDist = dist;
+            nearest = messagePositions[i];
+        }
+    }
+    return nearest;
+}
+
+function findNearestMessageAtOrBelow(y, startCy) {
+    // Find the nearest message whose cy >= startCy (so the bar can't go above start)
+    let nearest = null;
+    let minDist = Infinity;
+    for (const msg of messagePositions) {
+        if (msg.cy < startCy) continue;
+        const dist = Math.abs(y - msg.cy);
+        if (dist < minDist) {
+            minDist = dist;
+            nearest = msg;
+        }
+    }
+    return nearest;
+}
+
 // --- Ghost activation bar (translucent preview rect on the lifeline) ---
 
-function showGhostActivationBar(svgElement, cx, startY, endY) {
+function showGhostActivationBar(svgElement, cx, startCy, endCy) {
     const g = svgElement.querySelector('g');
     if (!g) return;
 
@@ -22,8 +77,8 @@ function showGhostActivationBar(svgElement, cx, startY, endY) {
         ghostActivationBar.setAttribute('opacity', '0.7');
         ghostActivationBar.setAttribute('pointer-events', 'none');
     }
-    const top = Math.min(startY, endY);
-    const height = Math.abs(endY - startY);
+    const top = Math.min(startCy, endCy);
+    const height = Math.max(Math.abs(endCy - startCy), 4); // minimum 4px height
     ghostActivationBar.setAttribute('x', cx - ACTIVATION_BAR_WIDTH / 2);
     ghostActivationBar.setAttribute('y', top);
     ghostActivationBar.setAttribute('width', ACTIVATION_BAR_WIDTH);
@@ -46,23 +101,34 @@ function isActivationAddMode() {
 function cancelActivationAddMode() {
     isAddActivationActive = false;
     activationOrigin = null;
-    activationEndY = null;
+    activationEndMessage = null;
     hideGhostActivationBar();
 }
 
 // --- Coordinator hooks (called from setupLifelineInteraction) ---
 
-// Stretch the ghost bar from the start Y down to the cursor Y on the origin lifeline.
 function handleActivationMouseMove(svgContainer, y) {
     if (!activationOrigin) return;
-    const endY = Math.max(y, activationOrigin.startY);
-    showGhostActivationBar(svgContainer, activationOrigin.cx, activationOrigin.startY, endY);
+
+    // Snap end to nearest message at or below start
+    const endMsg = findNearestMessageAtOrBelow(y, activationOrigin.startCy);
+    if (!endMsg) return;
+
+    showGhostActivationBar(
+        svgContainer,
+        activationOrigin.cx,
+        activationOrigin.startCy,
+        endMsg.cy
+    );
 }
 
-// Confirm the end of the bar and open the Deactivate/Destroy chooser.
 function handleActivationClick(e, y) {
     if (!activationOrigin) return;
-    activationEndY = Math.max(y, activationOrigin.startY);
+
+    // Snap to nearest message at or below start
+    const endMsg = findNearestMessageAtOrBelow(y, activationOrigin.startCy);
+    if (!endMsg) return;
+    activationEndMessage = endMsg;
     isAddActivationActive = false;
     hideGhostActivationBar();
 
@@ -77,11 +143,18 @@ function handleActivationClick(e, y) {
 function activationEventListeners() {
     // "Activate" context menu item enters activation-add mode.
     document.getElementById('seq-addActivation').addEventListener('click', () => {
-        cancelMessageAddMode();
+        if (messagePositions.length === 0) return; // No messages to anchor to
+        if (!messageOrigin || !firstClickCoordinates) return; // No lifeline context
+
+        // Snap start to nearest message from the right-click Y
+        const startMsg = findNearestMessage(firstClickCoordinates[1]);
+        if (!startMsg) return;
+
         activationOrigin = {
             cx: messageOrigin.cx,
             name: messageOrigin.name,
-            startY: firstClickCoordinates[1]
+            startMessageIndex: startMsg.index,
+            startCy: startMsg.cy
         };
         isAddActivationActive = true;
         hideIndicatorCircle();
@@ -106,14 +179,12 @@ function activationEventListeners() {
 
 async function submitActivation(endType) {
     document.getElementById('activation-end-menu').style.display = 'none';
-    if (!activationOrigin || activationEndY === null) return;
+    if (!activationOrigin || !activationEndMessage) return;
 
-    const element = document.getElementById('colb');
-    const svg = element.querySelector('g');
     const origin = activationOrigin;
-    const endY = activationEndY;
+    const endMsg = activationEndMessage;
     activationOrigin = null;
-    activationEndY = null;
+    activationEndMessage = null;
 
     try {
         const plantuml = trimlines(editor.session.getValue());
@@ -122,10 +193,9 @@ async function submitActivation(endType) {
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
                 plantuml: plantuml,
-                svg: svg.innerHTML,
                 participant: origin.name,
-                startY: origin.startY,
-                endY: endY,
+                startMessageIndex: origin.startMessageIndex,
+                endMessageIndex: endMsg.index,
                 endType: endType
             })
         });

--- a/src/plantuml_gui/static/sequence-activation.js
+++ b/src/plantuml_gui/static/sequence-activation.js
@@ -1,0 +1,141 @@
+// State for the add-activation interaction flow
+let isAddActivationActive = false;
+let activationOrigin = null; // {cx, name, startY}
+let activationEndY = null;
+
+// Reusable ghost bar overlay element (created once, moved on each frame)
+let ghostActivationBar = null;
+
+const ACTIVATION_BAR_WIDTH = 10;
+
+// --- Ghost activation bar (translucent preview rect on the lifeline) ---
+
+function showGhostActivationBar(svgElement, cx, startY, endY) {
+    const g = svgElement.querySelector('g');
+    if (!g) return;
+
+    if (!ghostActivationBar) {
+        ghostActivationBar = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        ghostActivationBar.setAttribute('fill', '#b8cce4');
+        ghostActivationBar.setAttribute('stroke', '#5b9bd5');
+        ghostActivationBar.setAttribute('stroke-width', '1');
+        ghostActivationBar.setAttribute('opacity', '0.7');
+        ghostActivationBar.setAttribute('pointer-events', 'none');
+    }
+    const top = Math.min(startY, endY);
+    const height = Math.abs(endY - startY);
+    ghostActivationBar.setAttribute('x', cx - ACTIVATION_BAR_WIDTH / 2);
+    ghostActivationBar.setAttribute('y', top);
+    ghostActivationBar.setAttribute('width', ACTIVATION_BAR_WIDTH);
+    ghostActivationBar.setAttribute('height', height);
+    if (!ghostActivationBar.parentNode) g.appendChild(ghostActivationBar);
+}
+
+function hideGhostActivationBar() {
+    if (ghostActivationBar && ghostActivationBar.parentNode) {
+        ghostActivationBar.parentNode.removeChild(ghostActivationBar);
+    }
+}
+
+// --- Activation-add mode lifecycle ---
+
+function isActivationAddMode() {
+    return isAddActivationActive;
+}
+
+function cancelActivationAddMode() {
+    isAddActivationActive = false;
+    activationOrigin = null;
+    activationEndY = null;
+    hideGhostActivationBar();
+}
+
+// --- Coordinator hooks (called from setupLifelineInteraction) ---
+
+// Stretch the ghost bar from the start Y down to the cursor Y on the origin lifeline.
+function handleActivationMouseMove(svgContainer, y) {
+    if (!activationOrigin) return;
+    const endY = Math.max(y, activationOrigin.startY);
+    showGhostActivationBar(svgContainer, activationOrigin.cx, activationOrigin.startY, endY);
+}
+
+// Confirm the end of the bar and open the Deactivate/Destroy chooser.
+function handleActivationClick(e, y) {
+    if (!activationOrigin) return;
+    activationEndY = Math.max(y, activationOrigin.startY);
+    isAddActivationActive = false;
+    hideGhostActivationBar();
+
+    const menu = document.getElementById('activation-end-menu');
+    menu.style.display = 'block';
+    menu.style.left = e.pageX + 'px';
+    menu.style.top = e.pageY + 'px';
+}
+
+// --- Event listener registration (called from sequenceEventListeners) ---
+
+function activationEventListeners() {
+    // "Activate" context menu item enters activation-add mode.
+    document.getElementById('seq-addActivation').addEventListener('click', () => {
+        cancelMessageAddMode();
+        activationOrigin = {
+            cx: messageOrigin.cx,
+            name: messageOrigin.name,
+            startY: firstClickCoordinates[1]
+        };
+        isAddActivationActive = true;
+        hideIndicatorCircle();
+        document.getElementById('sequence-menu').style.display = 'none';
+    });
+
+    // Chooser items submit the activation with the chosen end type.
+    document.getElementById('activation-deactivate').addEventListener('click', () => {
+        submitActivation('deactivate');
+    });
+    document.getElementById('activation-destroy').addEventListener('click', () => {
+        submitActivation('destroy');
+    });
+
+    // Escape cancels activation-add mode.
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && isAddActivationActive) {
+            cancelActivationAddMode();
+        }
+    });
+}
+
+async function submitActivation(endType) {
+    document.getElementById('activation-end-menu').style.display = 'none';
+    if (!activationOrigin || activationEndY === null) return;
+
+    const element = document.getElementById('colb');
+    const svg = element.querySelector('g');
+    const origin = activationOrigin;
+    const endY = activationEndY;
+    activationOrigin = null;
+    activationEndY = null;
+
+    try {
+        const plantuml = trimlines(editor.session.getValue());
+        const response = await fetch("addActivation", {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                plantuml: plantuml,
+                svg: svg.innerHTML,
+                participant: origin.name,
+                startY: origin.startY,
+                endY: endY,
+                endType: endType
+            })
+        });
+        const data = await response.json();
+        if (data.error) {
+            displayErrorMessage(data.error);
+            return;
+        }
+        setPuml(data.plantuml);
+    } catch (error) {
+        displayErrorMessage(`Error with fetch API: ${error.message}`, error);
+    }
+}

--- a/src/plantuml_gui/static/sequence-activation.js
+++ b/src/plantuml_gui/static/sequence-activation.js
@@ -191,9 +191,10 @@ function activationEventListeners() {
         }
     });
 
-    // Escape cancels activation-add mode.
+    // Escape cancels activation flow (both drag and end-type chooser).
     document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && isAddActivationActive) {
+        if (e.key === 'Escape' && (isAddActivationActive || activationOrigin)) {
+            document.getElementById('activation-end-menu').style.display = 'none';
             cancelActivationAddMode();
         }
     });

--- a/src/plantuml_gui/static/sequence-activation.js
+++ b/src/plantuml_gui/static/sequence-activation.js
@@ -169,6 +169,28 @@ function activationEventListeners() {
         submitActivation('destroy');
     });
 
+    // "Delete" on an existing bar removes its activate + close pair.
+    document.getElementById('seq-deleteActivation').addEventListener('click', async () => {
+        const element = document.getElementById('colb');
+        const svg = element.querySelector('g');
+        try {
+            const plantuml = trimlines(editor.session.getValue());
+            const response = await fetch("deleteActivation", {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    plantuml: plantuml,
+                    svg: svg.innerHTML,
+                    svgelement: lastclickedsvgelement.outerHTML
+                })
+            });
+            const data = await response.json();
+            setPuml(data.plantuml);
+        } catch (error) {
+            displayErrorMessage(`Error with fetch API: ${error.message}`, error);
+        }
+    });
+
     // Escape cancels activation-add mode.
     document.addEventListener('keydown', (e) => {
         if (e.key === 'Escape' && isAddActivationActive) {

--- a/src/plantuml_gui/static/sequence-message.js
+++ b/src/plantuml_gui/static/sequence-message.js
@@ -145,6 +145,7 @@ function backgroundContextMenu(e, svgElement) {
     const cy = transformed.y;
 
     if (isAddMessageActive) return;
+    if (isActivationAddMode()) return;
 
     const lifeline = findNearestLifeline(cx, cy, participantLifelines);
 
@@ -179,6 +180,9 @@ function setupLifelineInteraction(svgContainer) {
                 hideGhostArrow();
             }
             hideIndicatorCircle();
+        } else if (isActivationAddMode()) {
+            handleActivationMouseMove(svgContainer, y);
+            hideIndicatorCircle();
         } else {
             hideGhostArrow();
             const lifeline = findNearestLifeline(x, y, participantLifelines);
@@ -192,8 +196,19 @@ function setupLifelineInteraction(svgContainer) {
 
     // Click: confirm destination and open label dialog
     container.addEventListener('click', (e) => {
-        if (!isAddMessageActive || !messageOrigin) return;
         if (!svgContainer || !svgContainer.getScreenCTM()) return;
+
+        // Activation-add mode: confirm the bar end and open the end-type chooser.
+        if (isActivationAddMode()) {
+            const transformed = svgPointFromEvent(e, svgContainer);
+            // Stop propagation so the global menu-dismiss handler does not
+            // immediately hide the chooser we are about to show.
+            e.stopPropagation();
+            handleActivationClick(e, transformed.y);
+            return;
+        }
+
+        if (!isAddMessageActive || !messageOrigin) return;
 
         const transformed = svgPointFromEvent(e, svgContainer);
         const x = transformed.x;

--- a/src/plantuml_gui/static/sequence-message.js
+++ b/src/plantuml_gui/static/sequence-message.js
@@ -162,11 +162,26 @@ function backgroundContextMenu(e, svgElement) {
 
 // --- Mouse interaction handlers ---
 
-function setupLifelineInteraction(svgContainer) {
+// Guards against attaching the container listeners more than once. The
+// listeners read the live svg on each event, so they survive re-renders and
+// must NOT be re-added per render (doing so stacked stale-closure handlers
+// that computed conflicting coordinates).
+let lifelineInteractionAttached = false;
+
+// Returns the current diagram svg element (replaced on every render).
+function getLiveSequenceSvg() {
+    const colb = document.getElementById('colb');
+    return colb ? colb.querySelector('svg') : null;
+}
+
+function setupLifelineInteraction() {
+    if (lifelineInteractionAttached) return;
+    lifelineInteractionAttached = true;
     const container = document.getElementById('colb-container');
 
     // Mousemove: show indicator in normal mode, ghost arrow in message-add mode
     container.addEventListener('mousemove', (e) => {
+        const svgContainer = getLiveSequenceSvg();
         if (!svgContainer || !svgContainer.getScreenCTM()) return;
         const transformed = svgPointFromEvent(e, svgContainer);
         const x = transformed.x;
@@ -196,6 +211,7 @@ function setupLifelineInteraction(svgContainer) {
 
     // Click: confirm destination and open label dialog
     container.addEventListener('click', (e) => {
+        const svgContainer = getLiveSequenceSvg();
         if (!svgContainer || !svgContainer.getScreenCTM()) return;
 
         // Activation-add mode: confirm the bar end and open the end-type chooser.

--- a/src/plantuml_gui/static/sequence-message.js
+++ b/src/plantuml_gui/static/sequence-message.js
@@ -154,6 +154,25 @@ function backgroundContextMenu(e, svgElement) {
     firstClickCoordinates = [lifeline.cx, cy];
     messageOrigin = {cx: lifeline.cx, y: cy, name: lifeline.name};
 
+    // If the right-click landed on an activation bar (a rect with the
+    // stroke:#181818;stroke-width:1.0 style; participant headers use 0.5 and the
+    // SVG background uses a transparent stroke), show the "Delete activation
+    // bar" item and remember the clicked bar for the delete request.
+    const target = e.target;
+    const onBar = target && target.tagName &&
+        target.tagName.toLowerCase() === 'rect' &&
+        (target.getAttribute('style') || '').includes('stroke:#181818;stroke-width:1.0');
+    const deleteItem = document.getElementById('seq-deleteActivation-item');
+    const deleteDivider = document.getElementById('seq-deleteActivation-divider');
+    if (onBar) {
+        lastclickedsvgelement = target;
+        deleteItem.style.display = '';
+        deleteDivider.style.display = '';
+    } else {
+        deleteItem.style.display = 'none';
+        deleteDivider.style.display = 'none';
+    }
+
     var contextMenu = document.getElementById('sequence-menu');
     contextMenu.style.display = 'block';
     contextMenu.style.left = e.pageX + 'px';

--- a/src/plantuml_gui/static/sequence-operations.js
+++ b/src/plantuml_gui/static/sequence-operations.js
@@ -232,7 +232,7 @@ function sequenceEventListeners() {
 
 // Called on every render when diagram type is sequence
 async function setHandlersForSequenceDiagram(pumlcontent, element) {
-    fetchSvgFromPlantUml().then((svgContent) => {
+    fetchSvgFromPlantUml().then(async (svgContent) => {
         element.innerHTML = svgContent;
         const svgContainer = element.querySelector('svg');
         const svg = element.querySelector('g');
@@ -242,7 +242,7 @@ async function setHandlersForSequenceDiagram(pumlcontent, element) {
         }
 
         extractLifelinePositions();
-        fetchMessagePositions();
+        await fetchMessagePositions();
         cancelMessageAddMode();
         cancelActivationAddMode();
 

--- a/src/plantuml_gui/static/sequence-operations.js
+++ b/src/plantuml_gui/static/sequence-operations.js
@@ -227,6 +227,7 @@ function sequenceEventListeners() {
     messageEventListeners();
     messageOperationEventListeners();
     noteOperationEventListeners();
+    activationEventListeners();
 }
 
 // Called on every render when diagram type is sequence
@@ -242,6 +243,7 @@ async function setHandlersForSequenceDiagram(pumlcontent, element) {
 
         extractLifelinePositions();
         cancelMessageAddMode();
+        cancelActivationAddMode();
 
         handleContextMenuBackground(svgContainer);
         setupLifelineInteraction(svgContainer);

--- a/src/plantuml_gui/static/sequence-operations.js
+++ b/src/plantuml_gui/static/sequence-operations.js
@@ -242,11 +242,12 @@ async function setHandlersForSequenceDiagram(pumlcontent, element) {
         }
 
         extractLifelinePositions();
+        fetchMessagePositions();
         cancelMessageAddMode();
         cancelActivationAddMode();
 
         handleContextMenuBackground(svgContainer);
-        setupLifelineInteraction(svgContainer);
+        setupLifelineInteraction();
         setupParticipantHandlers(svg.querySelectorAll('*'), svg, element);
         setupMessageHandlers(svg.querySelectorAll('*'), svg);
         setupNoteHandlers(svg.querySelectorAll('*'));

--- a/src/plantuml_gui/templates/index.html
+++ b/src/plantuml_gui/templates/index.html
@@ -53,6 +53,7 @@ SOFTWARE.
     <script src="https://unpkg.com/tippy.js@6"></script>
     <script src="static/script.js?v={{ script_hash }}"></script>
     <script src="static/sequence-message.js?v={{ script_hash }}"></script>
+    <script src="static/sequence-activation.js?v={{ script_hash }}"></script>
     <script src="static/sequence-operations.js?v={{ script_hash }}"></script>
     <script src="static/activity.js?v={{ script_hash }}"></script>
     <link rel="stylesheet" href="static/styles.css">

--- a/src/plantuml_gui/templates/partials/sequence_menus.html
+++ b/src/plantuml_gui/templates/partials/sequence_menus.html
@@ -54,7 +54,13 @@
 <div class="dropdown-menu" id="sequence-menu">
   <li><a class="dropdown-item" href="#" id="addMessageSolid">Add Message <span style="display:inline-block;width:20px;border-top:2px solid #333;vertical-align:middle;margin-left:4px"></span></a></li>
   <li><a class="dropdown-item" href="#" id="addMessageDashed">Add Message <span style="display:inline-block;width:20px;border-top:2px dashed #333;vertical-align:middle;margin-left:4px"></span></a></li>
+  <li><a class="dropdown-item" href="#" id="seq-addActivation">Activate <span style="display:inline-block;width:6px;height:14px;background:#fff;border:1px solid #333;vertical-align:middle;margin-left:4px"></span></a></li>
   <li><a class="dropdown-item" href="#" id="seq-addNote">Add Note &#9998;</a></li>
+</div>
+
+<div class="dropdown-menu" id="activation-end-menu">
+  <li><a class="dropdown-item" href="#" id="activation-deactivate">Deactivate</a></li>
+  <li><a class="dropdown-item" href="#" id="activation-destroy">Destroy &#10005;</a></li>
 </div>
 
 <div class="dropdown-menu" id="seq-note-placement-menu">

--- a/src/plantuml_gui/templates/partials/sequence_menus.html
+++ b/src/plantuml_gui/templates/partials/sequence_menus.html
@@ -56,6 +56,8 @@
   <li><a class="dropdown-item" href="#" id="addMessageDashed">Add Message <span style="display:inline-block;width:20px;border-top:2px dashed #333;vertical-align:middle;margin-left:4px"></span></a></li>
   <li><a class="dropdown-item" href="#" id="seq-addActivation">Activate <span style="display:inline-block;width:6px;height:14px;background:#fff;border:1px solid #333;vertical-align:middle;margin-left:4px"></span></a></li>
   <li><a class="dropdown-item" href="#" id="seq-addNote">Add Note &#9998;</a></li>
+  <li id="seq-deleteActivation-divider" style="display:none"><hr class="dropdown-divider"></li>
+  <li id="seq-deleteActivation-item" style="display:none"><a class="dropdown-item" href="#" id="seq-deleteActivation">Delete activation bar</a></li>
 </div>
 
 <div class="dropdown-menu" id="activation-end-menu">

--- a/tests/e2e/test_sequence_activation.py
+++ b/tests/e2e/test_sequence_activation.py
@@ -230,3 +230,97 @@ class TestActivationFlow:
         )
         assert lines.count("activate Bob") == 2
         assert lines.count("deactivate Bob") == 2
+
+
+class TestDeleteActivationFlow:
+    def _load_bar_diagram(self, page):
+        # The page renders its default demo once on load; that late async
+        # render can clobber #colb after our setValue. Re-render the sequence
+        # diagram until its activation bar is stably present (past the one-time
+        # demo render), which makes this robust regardless of render timing.
+        bar_present = """() => Array.from(document.querySelectorAll('#colb g rect'))
+            .some(r => (r.getAttribute('style') || '')
+                .includes('stroke:#181818;stroke-width:1.0')
+                && parseFloat(r.getAttribute('x')) < 200)"""
+        for _ in range(12):
+            page.evaluate("""() => {
+                editor.session.setValue(
+                    "@startuml\\nparticipant Alice\\nparticipant Bob\\n"
+                    + "Alice -> Bob: m1\\nactivate Bob\\nBob -> Alice: m2\\n"
+                    + "deactivate Bob\\nAlice -> Bob: m3\\n@enduml");
+            }""")
+            page.wait_for_timeout(2500)
+            if page.evaluate(bar_present):
+                return
+        raise AssertionError("activation bar never rendered")
+
+    def _right_click_bar(self, page):
+        # Dispatch a contextmenu on the activation bar at mapped client coords so
+        # it bubbles to the background handler (which detects the bar target).
+        return page.evaluate("""() => {
+            const bar = Array.from(document.querySelectorAll('#colb g rect'))
+                .find(r => (r.getAttribute('style') || '').includes('stroke:#181818;stroke-width:1.0'));
+            if (!bar) return false;
+            const svg = document.querySelector('#colb svg');
+            const x = parseFloat(bar.getAttribute('x'))
+                + parseFloat(bar.getAttribute('width')) / 2;
+            const y = parseFloat(bar.getAttribute('y')) + 5;
+            const pt = svg.createSVGPoint();
+            pt.x = x; pt.y = y;
+            const s = pt.matrixTransform(svg.getScreenCTM());
+            bar.dispatchEvent(new MouseEvent('contextmenu',
+                {bubbles: true, cancelable: true, clientX: s.x, clientY: s.y}));
+            return true;
+        }""")
+
+    def test_right_click_bar_shows_delete_in_sequence_menu(self, app_url, page):
+        self._load_bar_diagram(page)
+        assert self._right_click_bar(page) is True
+        state = page.evaluate("""() => ({
+            menu: document.getElementById('sequence-menu').style.display,
+            del: document.getElementById('seq-deleteActivation-item').style.display,
+            addMsg: document.getElementById('addMessageSolid') !== null,
+            activate: document.getElementById('seq-addActivation') !== null
+        })""")
+        # Full lifeline menu is shown, with the Delete item now visible.
+        assert state["menu"] == "block"
+        assert state["del"] != "none"
+        assert state["addMsg"] is True
+        assert state["activate"] is True
+
+    def test_delete_bar_removes_lines(self, app_url, page):
+        self._load_bar_diagram(page)
+        self._right_click_bar(page)
+        page.evaluate("() => document.getElementById('seq-deleteActivation').click()")
+        page.wait_for_timeout(5000)
+
+        lines = page.evaluate(
+            "() => editor.session.getValue().split('\\n').map(l => l.trim())"
+        )
+        assert "activate Bob" not in lines
+        assert "deactivate Bob" not in lines
+        # Messages remain.
+        assert "Alice -> Bob: m1" in lines
+        assert "Bob -> Alice: m2" in lines
+
+    def test_delete_item_hidden_when_not_on_bar(self, app_url, page):
+        self._load_bar_diagram(page)
+        # Right-click the lifeline line (not a bar rect), near its bottom.
+        hidden = page.evaluate("""() => {
+            const svg = document.querySelector('#colb svg');
+            const lines = Array.from(document.querySelectorAll('#colb g line'))
+                .filter(l => (l.getAttribute('style') || '').includes('stroke-dasharray'));
+            if (lines.length === 0) return 'no-lifeline';
+            // Rightmost dashed lifeline is Bob's.
+            const line = lines.reduce((a, b) =>
+                parseFloat(a.getAttribute('x1')) > parseFloat(b.getAttribute('x1')) ? a : b);
+            const x = parseFloat(line.getAttribute('x1'));
+            const y2 = parseFloat(line.getAttribute('y2'));
+            const pt = svg.createSVGPoint();
+            pt.x = x; pt.y = y2 - 3;
+            const s = pt.matrixTransform(svg.getScreenCTM());
+            line.dispatchEvent(new MouseEvent('contextmenu',
+                {bubbles: true, cancelable: true, clientX: s.x, clientY: s.y}));
+            return document.getElementById('seq-deleteActivation-item').style.display;
+        }""")
+        assert hidden == "none"

--- a/tests/e2e/test_sequence_activation.py
+++ b/tests/e2e/test_sequence_activation.py
@@ -44,6 +44,56 @@ class TestActivationMenus:
 
 
 class TestActivationAddMode:
+    def test_lifeline_listeners_do_not_accumulate(self, app_url, page):
+        """Re-rendering must not stack duplicate mousemove handlers.
+
+        Regression: setupLifelineInteraction used to add a listener (capturing a
+        now-stale svg) on every render, so one mouse move ran the handler many
+        times with conflicting coordinates -- breaking the ghost and placing the
+        bar using a stale click. After the fix the handler runs exactly once.
+        """
+        # Re-render several times with growing diagrams to attempt accumulation.
+        for msgs in [
+            "A1 -> A2: a",
+            "A1 -> A2: a\\nA2 -> A1: b",
+            "A1 -> A2: a\\nA2 -> A1: b\\nA1 -> A2: c",
+        ]:
+            page.evaluate(
+                """(msgs) => {
+                    editor.session.setValue(
+                        "@startuml\\nparticipant A1\\nparticipant A2\\n"
+                        + msgs + "\\n@enduml");
+                }""",
+                msgs,
+            )
+            page.wait_for_timeout(3000)
+
+        count = page.evaluate("""() => {
+            window.__amm = 0;
+            const orig = handleActivationMouseMove;
+            handleActivationMouseMove = function() {
+                window.__amm++;
+                return orig.apply(this, arguments);
+            };
+            // Enter activation mode with a synthetic origin (the count does not
+            // depend on real snapping data, only on how many listeners fire).
+            activationOrigin = {cx: 80, name: 'A2', startMessageIndex: 3, startCy: 60};
+            isAddActivationActive = true;
+
+            const svg = document.querySelector('#colb svg');
+            const r = svg.getBoundingClientRect();
+            document.getElementById('colb-container').dispatchEvent(
+                new MouseEvent('mousemove',
+                    {clientX: r.x + r.width / 2,
+                     clientY: r.y + r.height / 2, bubbles: true}));
+
+            const c = window.__amm;
+            handleActivationMouseMove = orig;
+            cancelActivationAddMode();
+            return c;
+        }""")
+        assert count == 1
+
     def test_is_activation_add_mode_reflects_flag(self, app_url, page):
         """isActivationAddMode reflects the mode flag."""
         result = page.evaluate("""() => {
@@ -57,28 +107,28 @@ class TestActivationAddMode:
         assert result["off"] is False
 
     def test_cancel_activation_add_mode_resets_state(self, app_url, page):
-        """cancelActivationAddMode clears mode and origin."""
+        """cancelActivationAddMode clears mode, origin, and end message."""
         result = page.evaluate("""() => {
             isAddActivationActive = true;
-            activationOrigin = {cx: 50, name: 'Bob', startY: 40};
-            activationEndY = 90;
+            activationOrigin = {cx: 50, name: 'Bob', startMessageIndex: 3, startCy: 40};
+            activationEndMessage = {index: 4, cy: 90};
             cancelActivationAddMode();
             return {
                 active: isAddActivationActive,
                 origin: activationOrigin,
-                endY: activationEndY
+                endMessage: activationEndMessage
             };
         }""")
         assert result["active"] is False
         assert result["origin"] is None
-        assert result["endY"] is None
+        assert result["endMessage"] is None
 
     def test_escape_cancels_activation_mode(self, app_url, page):
         """Pressing Escape cancels activation-add mode."""
         result = page.evaluate("""() => {
             sequenceEventListeners();
             isAddActivationActive = true;
-            activationOrigin = {cx: 50, name: 'Bob', startY: 40};
+            activationOrigin = {cx: 50, name: 'Bob', startMessageIndex: 3, startCy: 40};
             document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
             return isActivationAddMode();
         }""")
@@ -100,10 +150,11 @@ class TestActivationFlow:
         names = page.evaluate("() => participantLifelines.map(l => l.name)")
         assert names == ["Alice", "Bob"]
 
+        # hello is at line index 3 in the loaded puml
         page.evaluate("""() => {
             const bob = participantLifelines[1];
-            activationOrigin = {cx: bob.cx, name: bob.name, startY: bob.yTop + 5};
-            activationEndY = bob.yBottom - 5;
+            activationOrigin = {cx: bob.cx, name: bob.name, startMessageIndex: 3, startCy: 60};
+            activationEndMessage = {index: 3, cy: 60};
             submitActivation('deactivate');
         }""")
         page.wait_for_timeout(5000)
@@ -120,8 +171,8 @@ class TestActivationFlow:
 
         page.evaluate("""() => {
             const bob = participantLifelines[1];
-            activationOrigin = {cx: bob.cx, name: bob.name, startY: bob.yTop + 5};
-            activationEndY = bob.yBottom - 5;
+            activationOrigin = {cx: bob.cx, name: bob.name, startMessageIndex: 3, startCy: 60};
+            activationEndMessage = {index: 3, cy: 60};
             submitActivation('destroy');
         }""")
         page.wait_for_timeout(5000)
@@ -131,3 +182,51 @@ class TestActivationFlow:
         )
         assert "activate Bob" in lines
         assert "destroy Bob" in lines
+
+    def test_second_bar_uses_refreshed_message_positions(self, app_url, page):
+        """Adding a second bar must work once one already exists.
+
+        After the first bar renders, fetchMessagePositions runs against an SVG
+        that now contains an activation rect. This is the scenario that used to
+        500 (activation rect mistaken for a participant). Verify message
+        positions still resolve and a second balanced bar is added.
+        """
+        # Three messages so positions are unambiguous.
+        page.evaluate("""() => {
+            editor.session.setValue(
+                "@startuml\\nparticipant Alice\\nparticipant Bob\\n"
+                + "Alice -> Bob: m1\\nBob -> Alice: m2\\nAlice -> Bob: m3\\n@enduml");
+        }""")
+        page.wait_for_timeout(5000)
+
+        # First bar around the first message, driven by the fetched positions.
+        page.evaluate("""() => {
+            const bob = participantLifelines[1];
+            const m = messagePositions[0];
+            activationOrigin = {cx: bob.cx, name: bob.name,
+                                startMessageIndex: m.index, startCy: m.cy};
+            activationEndMessage = {index: m.index, cy: m.cy};
+            submitActivation('deactivate');
+        }""")
+        page.wait_for_timeout(5000)
+
+        # After the bar rendered, positions must still resolve (no 500).
+        msg_count = page.evaluate("() => messagePositions.length")
+        assert msg_count == 3
+
+        # Second bar around the last message.
+        page.evaluate("""() => {
+            const bob = participantLifelines[1];
+            const m = messagePositions[messagePositions.length - 1];
+            activationOrigin = {cx: bob.cx, name: bob.name,
+                                startMessageIndex: m.index, startCy: m.cy};
+            activationEndMessage = {index: m.index, cy: m.cy};
+            submitActivation('deactivate');
+        }""")
+        page.wait_for_timeout(5000)
+
+        lines = page.evaluate(
+            "() => editor.session.getValue().split('\\n').map(l => l.trim())"
+        )
+        assert lines.count("activate Bob") == 2
+        assert lines.count("deactivate Bob") == 2

--- a/tests/e2e/test_sequence_activation.py
+++ b/tests/e2e/test_sequence_activation.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2026 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""End-to-end tests for sequence diagram activation bar JS logic."""
+
+
+class TestActivationMenus:
+    def test_activate_menu_item_exists(self, app_url, page):
+        """The Activate item exists in the sequence (lifeline) context menu."""
+        result = page.evaluate(
+            "() => document.getElementById('seq-addActivation') !== null"
+        )
+        assert result is True
+
+    def test_end_type_chooser_exists(self, app_url, page):
+        """The Deactivate/Destroy chooser and its items exist in the DOM."""
+        result = page.evaluate("""() => {
+            return document.getElementById('activation-end-menu') !== null
+                && document.getElementById('activation-deactivate') !== null
+                && document.getElementById('activation-destroy') !== null;
+        }""")
+        assert result is True
+
+
+class TestActivationAddMode:
+    def test_is_activation_add_mode_reflects_flag(self, app_url, page):
+        """isActivationAddMode reflects the mode flag."""
+        result = page.evaluate("""() => {
+            isAddActivationActive = true;
+            const on = isActivationAddMode();
+            isAddActivationActive = false;
+            const off = isActivationAddMode();
+            return {on, off};
+        }""")
+        assert result["on"] is True
+        assert result["off"] is False
+
+    def test_cancel_activation_add_mode_resets_state(self, app_url, page):
+        """cancelActivationAddMode clears mode and origin."""
+        result = page.evaluate("""() => {
+            isAddActivationActive = true;
+            activationOrigin = {cx: 50, name: 'Bob', startY: 40};
+            activationEndY = 90;
+            cancelActivationAddMode();
+            return {
+                active: isAddActivationActive,
+                origin: activationOrigin,
+                endY: activationEndY
+            };
+        }""")
+        assert result["active"] is False
+        assert result["origin"] is None
+        assert result["endY"] is None
+
+    def test_escape_cancels_activation_mode(self, app_url, page):
+        """Pressing Escape cancels activation-add mode."""
+        result = page.evaluate("""() => {
+            sequenceEventListeners();
+            isAddActivationActive = true;
+            activationOrigin = {cx: 50, name: 'Bob', startY: 40};
+            document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+            return isActivationAddMode();
+        }""")
+        assert result is False
+
+
+class TestActivationFlow:
+    def _load_diagram(self, page):
+        page.evaluate("""() => {
+            editor.session.setValue(
+                "@startuml\\nparticipant Alice\\nparticipant Bob\\n"
+                + "Alice -> Bob: hello\\n@enduml");
+        }""")
+        page.wait_for_timeout(5000)
+
+    def test_deactivate_flow_updates_puml(self, app_url, page):
+        """A full activate -> deactivate gesture adds a balanced pair to the puml."""
+        self._load_diagram(page)
+        names = page.evaluate("() => participantLifelines.map(l => l.name)")
+        assert names == ["Alice", "Bob"]
+
+        page.evaluate("""() => {
+            const bob = participantLifelines[1];
+            activationOrigin = {cx: bob.cx, name: bob.name, startY: bob.yTop + 5};
+            activationEndY = bob.yBottom - 5;
+            submitActivation('deactivate');
+        }""")
+        page.wait_for_timeout(5000)
+
+        lines = page.evaluate(
+            "() => editor.session.getValue().split('\\n').map(l => l.trim())"
+        )
+        assert "activate Bob" in lines
+        assert "deactivate Bob" in lines
+
+    def test_destroy_flow_updates_puml(self, app_url, page):
+        """A full activate -> destroy gesture adds activate + destroy to the puml."""
+        self._load_diagram(page)
+
+        page.evaluate("""() => {
+            const bob = participantLifelines[1];
+            activationOrigin = {cx: bob.cx, name: bob.name, startY: bob.yTop + 5};
+            activationEndY = bob.yBottom - 5;
+            submitActivation('destroy');
+        }""")
+        page.wait_for_timeout(5000)
+
+        lines = page.evaluate(
+            "() => editor.session.getValue().split('\\n').map(l => l.trim())"
+        )
+        assert "activate Bob" in lines
+        assert "destroy Bob" in lines

--- a/tests/sequence/test_activation.py
+++ b/tests/sequence/test_activation.py
@@ -28,7 +28,6 @@ import re
 
 from flask import json
 from plantuml_gui.sequence.activation import add_activation
-from plantuml_gui.shared.render import _create_svg_from_uml
 
 THREE_MESSAGE_PUML = """@startuml
 participant alice
@@ -38,69 +37,84 @@ bob -> alice: m2
 alice -> bob: m3
 @enduml"""
 
-# Message Y-positions for THREE_MESSAGE_PUML (from the rendered SVG):
-#   m1 ~ 67.4, m2 ~ 96.6, m3 ~ 125.7
-# These constants pick points that fall between messages.
-Y_BEFORE_M2 = 80.0
-Y_AFTER_M2 = 110.0
-Y_BEFORE_M1 = 55.0
-Y_AFTER_M3 = 140.0
-
-
-def extract_g_element(svg_string):
-    match = re.search(r"<g>(.*?)</g>", svg_string, re.DOTALL)
-    if match:
-        return f"<g>{match.group(1)}</g>"
-    return None
-
-
-def svg_for(puml):
-    return extract_g_element(_create_svg_from_uml(puml))
+# Line indexes in THREE_MESSAGE_PUML:
+#   line 0: @startuml
+#   line 1: participant alice
+#   line 2: participant bob
+#   line 3: alice -> bob: m1
+#   line 4: bob -> alice: m2
+#   line 5: alice -> bob: m3
+#   line 6: @enduml
+M1_INDEX = 3
+M2_INDEX = 4
+M3_INDEX = 5
 
 
 class TestAddActivation:
-    def test_activate_deactivate_wraps_message(self):
-        svg = svg_for(THREE_MESSAGE_PUML)
+    def test_activate_inserted_after_start_message(self):
+        # Bar from m1 (start) to m2 (end): activate sits just below the start
+        # message (m1), so m1 is above the bar and m2 is inside it.
         result = add_activation(
-            THREE_MESSAGE_PUML, svg, "bob", Y_BEFORE_M2, Y_AFTER_M2, "deactivate"
+            THREE_MESSAGE_PUML, "bob", M1_INDEX, M2_INDEX, "deactivate"
         )
         lines = result.splitlines()
         activate_at = lines.index("activate bob")
         deactivate_at = lines.index("deactivate bob")
-        # activate precedes its close, and the bar wraps the m2 message line.
         assert activate_at < deactivate_at
-        assert lines[activate_at + 1] == "bob -> alice: m2"
-        assert lines[deactivate_at - 1] == "bob -> alice: m2"
+        assert lines[activate_at - 1] == "alice -> bob: m1"  # activate is below m1
+        assert lines[activate_at + 1] == "bob -> alice: m2"  # m2 is inside the bar
+        assert lines[deactivate_at - 1] == "bob -> alice: m2"  # close is below m2
 
     def test_destroy_produces_destroy_line(self):
-        svg = svg_for(THREE_MESSAGE_PUML)
         result = add_activation(
-            THREE_MESSAGE_PUML, svg, "bob", Y_BEFORE_M2, Y_AFTER_M2, "destroy"
+            THREE_MESSAGE_PUML, "bob", M2_INDEX, M2_INDEX, "destroy"
         )
         assert "activate bob" in result
         assert "destroy bob" in result
         assert "deactivate bob" not in result
 
     def test_balanced_pair_is_added(self):
-        svg = svg_for(THREE_MESSAGE_PUML)
         result = add_activation(
-            THREE_MESSAGE_PUML, svg, "alice", Y_BEFORE_M1, Y_AFTER_M3, "deactivate"
+            THREE_MESSAGE_PUML, "alice", M1_INDEX, M3_INDEX, "deactivate"
         )
         lines = result.splitlines()
         assert lines.count("activate alice") == 1
         assert lines.count("deactivate alice") == 1
 
+    def test_activate_before_deactivate(self):
+        result = add_activation(
+            THREE_MESSAGE_PUML, "alice", M1_INDEX, M3_INDEX, "deactivate"
+        )
+        lines = result.splitlines()
+        activate_at = lines.index("activate alice")
+        deactivate_at = lines.index("deactivate alice")
+        assert activate_at < deactivate_at
+
+    def test_bar_covers_messages_after_start_through_end(self):
+        # start=m1, end=m3: activate is below m1, close is below m3, so the bar
+        # excludes the start message (m1) and includes m2 and m3.
+        result = add_activation(
+            THREE_MESSAGE_PUML, "alice", M1_INDEX, M3_INDEX, "deactivate"
+        )
+        lines = result.splitlines()
+        activate_at = lines.index("activate alice")
+        deactivate_at = lines.index("deactivate alice")
+        # m1 is above the bar.
+        assert lines.index("alice -> bob: m1") < activate_at
+        # m2 and m3 are inside the bar.
+        assert activate_at < lines.index("bob -> alice: m2") < deactivate_at
+        assert activate_at < lines.index("alice -> bob: m3") < deactivate_at
+
     def test_nested_activation_stays_balanced_and_ordered(self):
-        svg = svg_for(THREE_MESSAGE_PUML)
         # Outer bar wraps all three messages.
         outer = add_activation(
-            THREE_MESSAGE_PUML, svg, "bob", Y_BEFORE_M1, Y_AFTER_M3, "deactivate"
+            THREE_MESSAGE_PUML, "bob", M1_INDEX, M3_INDEX, "deactivate"
         )
-        # Inner bar wraps only m2; reuse original svg coordinates (geometry of
-        # the original render is what the frontend would have sent).
-        nested = add_activation(
-            outer, svg, "bob", Y_BEFORE_M2, Y_AFTER_M2, "deactivate"
-        )
+        # Inner bar wraps only m2.  The outer insert shifted line numbers, so
+        # find the current index of m2 in the modified puml.
+        outer_lines = outer.splitlines()
+        m2_idx = next(i for i, ln in enumerate(outer_lines) if ln == "bob -> alice: m2")
+        nested = add_activation(outer, "bob", m2_idx, m2_idx, "deactivate")
         lines = nested.splitlines()
         activate_positions = [i for i, ln in enumerate(lines) if ln == "activate bob"]
         deactivate_positions = [
@@ -111,16 +125,60 @@ class TestAddActivation:
         # Properly nested: both activates come before both deactivates.
         assert max(activate_positions) < min(deactivate_positions)
 
+    def test_unknown_end_type_defaults_to_deactivate(self):
+        result = add_activation(THREE_MESSAGE_PUML, "bob", M2_INDEX, M2_INDEX, "bogus")
+        assert "activate bob" in result
+        assert "deactivate bob" in result
+        assert "destroy bob" not in result
+
+
+class TestParsingWithExistingActivationBar:
+    """Regression: a diagram that already contains an activation bar must still
+    parse. The bar's narrow rect shares the lifeline's cx, so it must not be
+    mistaken for a participant (which previously corrupted message parsing and
+    returned HTTP 500 from getMessagePositions / addMessage / addActivation)."""
+
+    PUML_WITH_BAR = """@startuml
+participant alice
+participant bob
+alice -> bob: m1
+activate bob
+bob -> alice: m2
+deactivate bob
+alice -> bob: m3
+@enduml"""
+
+    def _svg(self):
+        from plantuml_gui.shared.render import _create_svg_from_uml
+
+        full = _create_svg_from_uml(self.PUML_WITH_BAR)
+        return re.search(r"<g>(.*?)</g>", full, re.DOTALL).group(1)
+
+    def test_get_message_positions_with_bar(self):
+        from plantuml_gui.sequence.message import get_message_positions
+
+        positions = get_message_positions(self.PUML_WITH_BAR, self._svg())
+        # Three messages, indexes skip the activate/deactivate lines (4 and 6).
+        assert [p["index"] for p in positions] == [3, 5, 7]
+        assert [p["text"] for p in positions] == ["m1", "m2", "m3"]
+
+    def test_get_message_positions_route_with_bar(self, client):
+        response = client.post(
+            "/getMessagePositions",
+            data=json.dumps({"plantuml": self.PUML_WITH_BAR, "svg": self._svg()}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert len(response.get_json()["positions"]) == 3
+
 
 class TestAddActivationRoute:
     def test_valid_request_returns_pair(self, client):
-        svg = svg_for(THREE_MESSAGE_PUML)
         payload = {
             "plantuml": THREE_MESSAGE_PUML,
-            "svg": svg,
             "participant": "bob",
-            "startY": Y_BEFORE_M2,
-            "endY": Y_AFTER_M2,
+            "startMessageIndex": M2_INDEX,
+            "endMessageIndex": M2_INDEX,
             "endType": "deactivate",
         }
         response = client.post(
@@ -134,13 +192,11 @@ class TestAddActivationRoute:
         assert "deactivate bob" in result
 
     def test_destroy_request_returns_destroy_line(self, client):
-        svg = svg_for(THREE_MESSAGE_PUML)
         payload = {
             "plantuml": THREE_MESSAGE_PUML,
-            "svg": svg,
             "participant": "bob",
-            "startY": Y_BEFORE_M2,
-            "endY": Y_AFTER_M2,
+            "startMessageIndex": M2_INDEX,
+            "endMessageIndex": M2_INDEX,
             "endType": "destroy",
         }
         response = client.post(
@@ -154,13 +210,11 @@ class TestAddActivationRoute:
         assert "destroy bob" in result
 
     def test_unknown_end_type_defaults_to_deactivate(self, client):
-        svg = svg_for(THREE_MESSAGE_PUML)
         payload = {
             "plantuml": THREE_MESSAGE_PUML,
-            "svg": svg,
             "participant": "bob",
-            "startY": Y_BEFORE_M2,
-            "endY": Y_AFTER_M2,
+            "startMessageIndex": M2_INDEX,
+            "endMessageIndex": M2_INDEX,
             "endType": "bogus",
         }
         response = client.post(

--- a/tests/sequence/test_activation.py
+++ b/tests/sequence/test_activation.py
@@ -27,7 +27,33 @@
 import re
 
 from flask import json
-from plantuml_gui.sequence.activation import add_activation
+from plantuml_gui.sequence.activation import add_activation, delete_activation
+from plantuml_gui.shared.render import _create_svg_from_uml
+from pyquery import PyQuery as Pq
+
+
+def _svg_g(puml):
+    """Render puml and return the inner HTML of the <g> element."""
+    full = _create_svg_from_uml(puml)
+    return re.search(r"<g>(.*?)</g>", full, re.DOTALL).group(1)
+
+
+def _activation_rects(svg_inner):
+    """Return [(x, y, outerHTML)] for activation bars, deduped, sorted by (y, x)."""
+    d = Pq("<g>" + svg_inner + "</g>")
+    seen = set()
+    rects = []
+    for rect in d("rect").items():
+        if "stroke:#181818;stroke-width:1.0" not in (rect.attr("style") or ""):
+            continue
+        x = float(rect.attr("x"))
+        y = float(rect.attr("y"))
+        if (x, y) in seen:
+            continue
+        seen.add((x, y))
+        rects.append((x, y, str(rect)))
+    return sorted(rects, key=lambda r: (r[1], r[0]))
+
 
 THREE_MESSAGE_PUML = """@startuml
 participant alice
@@ -172,6 +198,109 @@ alice -> bob: m3
         assert len(response.get_json()["positions"]) == 3
 
 
+class TestDeleteActivation:
+    SINGLE_BAR = """@startuml
+participant alice
+participant bob
+alice -> bob: m1
+activate bob
+bob -> alice: m2
+deactivate bob
+alice -> bob: m3
+@enduml"""
+
+    NESTED = """@startuml
+participant alice
+participant bob
+alice -> bob: m1
+activate bob
+bob -> alice: m2
+alice -> bob: m3
+activate bob
+bob -> alice: m4
+deactivate bob
+deactivate bob
+alice -> bob: m5
+@enduml"""
+
+    TWO_BARS = """@startuml
+participant alice
+participant bob
+alice -> bob: m1
+activate bob
+bob -> alice: m2
+deactivate bob
+alice -> bob: m3
+activate bob
+bob -> alice: m4
+deactivate bob
+alice -> bob: m5
+@enduml"""
+
+    DESTROY_BAR = """@startuml
+participant alice
+participant bob
+alice -> bob: m1
+activate bob
+bob -> alice: m2
+destroy bob
+alice -> bob: m3
+@enduml"""
+
+    def test_delete_single_bar(self):
+        svg = _svg_g(self.SINGLE_BAR)
+        rects = _activation_rects(svg)
+        assert len(rects) == 1
+        result = delete_activation(self.SINGLE_BAR, svg, rects[0][2])
+        assert "activate bob" not in result
+        assert "deactivate bob" not in result
+        # The messages are untouched.
+        for msg in ["alice -> bob: m1", "bob -> alice: m2", "alice -> bob: m3"]:
+            assert msg in result
+
+    def test_delete_outer_keeps_inner(self):
+        svg = _svg_g(self.NESTED)
+        rects = _activation_rects(svg)
+        assert len(rects) == 2
+        # rects sorted by (y, x): the outer bar starts higher up.
+        result = delete_activation(self.NESTED, svg, rects[0][2])
+        lines = result.splitlines()
+        assert lines.count("activate bob") == 1
+        assert lines.count("deactivate bob") == 1
+        # The surviving (inner) bar still wraps m4.
+        activate_at = lines.index("activate bob")
+        assert lines[activate_at - 1] == "alice -> bob: m3"
+
+    def test_delete_inner_keeps_outer(self):
+        svg = _svg_g(self.NESTED)
+        rects = _activation_rects(svg)
+        result = delete_activation(self.NESTED, svg, rects[1][2])
+        lines = result.splitlines()
+        assert lines.count("activate bob") == 1
+        assert lines.count("deactivate bob") == 1
+        # The surviving (outer) bar still starts below m1.
+        activate_at = lines.index("activate bob")
+        assert lines[activate_at - 1] == "alice -> bob: m1"
+
+    def test_delete_first_of_two_sequential(self):
+        svg = _svg_g(self.TWO_BARS)
+        rects = _activation_rects(svg)
+        assert len(rects) == 2
+        result = delete_activation(self.TWO_BARS, svg, rects[0][2])
+        lines = result.splitlines()
+        assert lines.count("activate bob") == 1
+        # The surviving (second) bar wraps m4, not m2.
+        activate_at = lines.index("activate bob")
+        assert lines[activate_at - 1] == "alice -> bob: m3"
+
+    def test_delete_destroy_bar(self):
+        svg = _svg_g(self.DESTROY_BAR)
+        rects = _activation_rects(svg)
+        result = delete_activation(self.DESTROY_BAR, svg, rects[0][2])
+        assert "activate bob" not in result
+        assert "destroy bob" not in result
+
+
 class TestAddActivationRoute:
     def test_valid_request_returns_pair(self, client):
         payload = {
@@ -226,3 +355,33 @@ class TestAddActivationRoute:
         result = response.get_json()["plantuml"]
         assert "activate bob" in result
         assert "deactivate bob" in result
+
+
+class TestDeleteActivationRoute:
+    SINGLE_BAR = """@startuml
+participant alice
+participant bob
+alice -> bob: m1
+activate bob
+bob -> alice: m2
+deactivate bob
+alice -> bob: m3
+@enduml"""
+
+    def test_delete_request_removes_bar(self, client):
+        svg = _svg_g(self.SINGLE_BAR)
+        rects = _activation_rects(svg)
+        payload = {
+            "plantuml": self.SINGLE_BAR,
+            "svg": svg,
+            "svgelement": rects[0][2],
+        }
+        response = client.post(
+            "/deleteActivation",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        result = response.get_json()["plantuml"]
+        assert "activate bob" not in result
+        assert "deactivate bob" not in result

--- a/tests/sequence/test_activation.py
+++ b/tests/sequence/test_activation.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2026 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for sequence diagram activation bars (activate/deactivate/destroy)."""
+
+import re
+
+from flask import json
+from plantuml_gui.sequence.activation import add_activation
+from plantuml_gui.shared.render import _create_svg_from_uml
+
+THREE_MESSAGE_PUML = """@startuml
+participant alice
+participant bob
+alice -> bob: m1
+bob -> alice: m2
+alice -> bob: m3
+@enduml"""
+
+# Message Y-positions for THREE_MESSAGE_PUML (from the rendered SVG):
+#   m1 ~ 67.4, m2 ~ 96.6, m3 ~ 125.7
+# These constants pick points that fall between messages.
+Y_BEFORE_M2 = 80.0
+Y_AFTER_M2 = 110.0
+Y_BEFORE_M1 = 55.0
+Y_AFTER_M3 = 140.0
+
+
+def extract_g_element(svg_string):
+    match = re.search(r"<g>(.*?)</g>", svg_string, re.DOTALL)
+    if match:
+        return f"<g>{match.group(1)}</g>"
+    return None
+
+
+def svg_for(puml):
+    return extract_g_element(_create_svg_from_uml(puml))
+
+
+class TestAddActivation:
+    def test_activate_deactivate_wraps_message(self):
+        svg = svg_for(THREE_MESSAGE_PUML)
+        result = add_activation(
+            THREE_MESSAGE_PUML, svg, "bob", Y_BEFORE_M2, Y_AFTER_M2, "deactivate"
+        )
+        lines = result.splitlines()
+        activate_at = lines.index("activate bob")
+        deactivate_at = lines.index("deactivate bob")
+        # activate precedes its close, and the bar wraps the m2 message line.
+        assert activate_at < deactivate_at
+        assert lines[activate_at + 1] == "bob -> alice: m2"
+        assert lines[deactivate_at - 1] == "bob -> alice: m2"
+
+    def test_destroy_produces_destroy_line(self):
+        svg = svg_for(THREE_MESSAGE_PUML)
+        result = add_activation(
+            THREE_MESSAGE_PUML, svg, "bob", Y_BEFORE_M2, Y_AFTER_M2, "destroy"
+        )
+        assert "activate bob" in result
+        assert "destroy bob" in result
+        assert "deactivate bob" not in result
+
+    def test_balanced_pair_is_added(self):
+        svg = svg_for(THREE_MESSAGE_PUML)
+        result = add_activation(
+            THREE_MESSAGE_PUML, svg, "alice", Y_BEFORE_M1, Y_AFTER_M3, "deactivate"
+        )
+        lines = result.splitlines()
+        assert lines.count("activate alice") == 1
+        assert lines.count("deactivate alice") == 1
+
+    def test_nested_activation_stays_balanced_and_ordered(self):
+        svg = svg_for(THREE_MESSAGE_PUML)
+        # Outer bar wraps all three messages.
+        outer = add_activation(
+            THREE_MESSAGE_PUML, svg, "bob", Y_BEFORE_M1, Y_AFTER_M3, "deactivate"
+        )
+        # Inner bar wraps only m2; reuse original svg coordinates (geometry of
+        # the original render is what the frontend would have sent).
+        nested = add_activation(
+            outer, svg, "bob", Y_BEFORE_M2, Y_AFTER_M2, "deactivate"
+        )
+        lines = nested.splitlines()
+        activate_positions = [i for i, ln in enumerate(lines) if ln == "activate bob"]
+        deactivate_positions = [
+            i for i, ln in enumerate(lines) if ln == "deactivate bob"
+        ]
+        assert len(activate_positions) == 2
+        assert len(deactivate_positions) == 2
+        # Properly nested: both activates come before both deactivates.
+        assert max(activate_positions) < min(deactivate_positions)
+
+
+class TestAddActivationRoute:
+    def test_valid_request_returns_pair(self, client):
+        svg = svg_for(THREE_MESSAGE_PUML)
+        payload = {
+            "plantuml": THREE_MESSAGE_PUML,
+            "svg": svg,
+            "participant": "bob",
+            "startY": Y_BEFORE_M2,
+            "endY": Y_AFTER_M2,
+            "endType": "deactivate",
+        }
+        response = client.post(
+            "/addActivation",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        result = response.get_json()["plantuml"]
+        assert "activate bob" in result
+        assert "deactivate bob" in result
+
+    def test_destroy_request_returns_destroy_line(self, client):
+        svg = svg_for(THREE_MESSAGE_PUML)
+        payload = {
+            "plantuml": THREE_MESSAGE_PUML,
+            "svg": svg,
+            "participant": "bob",
+            "startY": Y_BEFORE_M2,
+            "endY": Y_AFTER_M2,
+            "endType": "destroy",
+        }
+        response = client.post(
+            "/addActivation",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        result = response.get_json()["plantuml"]
+        assert "activate bob" in result
+        assert "destroy bob" in result
+
+    def test_unknown_end_type_defaults_to_deactivate(self, client):
+        svg = svg_for(THREE_MESSAGE_PUML)
+        payload = {
+            "plantuml": THREE_MESSAGE_PUML,
+            "svg": svg,
+            "participant": "bob",
+            "startY": Y_BEFORE_M2,
+            "endY": Y_AFTER_M2,
+            "endType": "bogus",
+        }
+        response = client.post(
+            "/addActivation",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        result = response.get_json()["plantuml"]
+        assert "activate bob" in result
+        assert "deactivate bob" in result


### PR DESCRIPTION
This pull request introduces activation bar support for sequence diagrams, allowing users to add, preview, and remove activation bars (including nested activations and destroy actions) via the UI. It includes both backend and frontend changes to support this feature, updates documentation, and improves SVG parsing robustness. Additionally, it enhances cache-busting for static JS files.

**Activation Bar Feature for Sequence Diagrams:**

* Added activation bar support: users can activate, deactivate, or destroy participants in sequence diagrams via the UI, with support for nested activations. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11) [[2]](diffhunk://#diff-0e40b74646edbfb06db3f21907c1b733d679d2cd52859d2e5885cb823a73fcaaR75-R80) [[3]](diffhunk://#diff-391feee052e3300c65d073196eaac856c8393d42e1419c53a8ee0b25c27e7d72R36)
* Implemented backend logic for activation bars, including the `add_activation` function and `/addActivation` and `/getMessagePositions` endpoints. [[1]](diffhunk://#diff-1ccd6eb78158af462b9f5b3428e3fa097aecdf9c3c4e7eb6f5bb04e7946c7549R1-R64) [[2]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dL27-R34) [[3]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dR75-R91) [[4]](diffhunk://#diff-7727a603ab7eea15cc9338edaf7ed8e236eca9ed0c22ef3e13ee46730c75504dR156-R163) [[5]](diffhunk://#diff-07a4267601f2a3e189fcb534b9238caf52acc18fe15548bf863494f066b13774R20) [[6]](diffhunk://#diff-07a4267601f2a3e189fcb534b9238caf52acc18fe15548bf863494f066b13774L78-R80) [[7]](diffhunk://#diff-6175e90722503185d14844d63b5939f41380290c9e5a2727fea835f3d334d88bR73-R74) [[8]](diffhunk://#diff-88b2f61cfb25e44e4aee4598ee31524a37756718f47f8bda13f2481f9f891ecfR128-R132) [[9]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR25-R28)
* Documented the new activation bar feature and API endpoints in `FEATURES.md`, `docs/frontend_backend_contract.md`, and `docs/routes.md`. [[1]](diffhunk://#diff-0e40b74646edbfb06db3f21907c1b733d679d2cd52859d2e5885cb823a73fcaaR75-R80) [[2]](diffhunk://#diff-6175e90722503185d14844d63b5939f41380290c9e5a2727fea835f3d334d88bR73-R74) [[3]](diffhunk://#diff-88b2f61cfb25e44e4aee4598ee31524a37756718f47f8bda13f2481f9f891ecfR128-R132)

**SVG Parsing and Robustness Improvements:**

* Improved SVG parsing to distinguish participant header rects from activation bars, preventing parsing errors and ensuring correct participant/message association even when activation bars are present. [[1]](diffhunk://#diff-c4064ee3ef169ba4311917fde645bd2059c3a7185d4fd2fd1a22390cf77cef20R30-R54) [[2]](diffhunk://#diff-c4064ee3ef169ba4311917fde645bd2059c3a7185d4fd2fd1a22390cf77cef20L90-R116) [[3]](diffhunk://#diff-c4064ee3ef169ba4311917fde645bd2059c3a7185d4fd2fd1a22390cf77cef20L109-R135) [[4]](diffhunk://#diff-c4064ee3ef169ba4311917fde645bd2059c3a7185d4fd2fd1a22390cf77cef20L137-R162) [[5]](diffhunk://#diff-c4064ee3ef169ba4311917fde645bd2059c3a7185d4fd2fd1a22390cf77cef20R192-R193) [[6]](diffhunk://#diff-0f65544bc3b1131ab09acfb86c197e3ffc4b182a79d63c3007fb12d8f0e070d1L31-R31) [[7]](diffhunk://#diff-0f65544bc3b1131ab09acfb86c197e3ffc4b182a79d63c3007fb12d8f0e070d1R53-R54)
* Updated message parsing to use a more robust participant lookup, preventing failures when arrow endpoints shift due to activation bars. [[1]](diffhunk://#diff-c4064ee3ef169ba4311917fde645bd2059c3a7185d4fd2fd1a22390cf77cef20L90-R116) [[2]](diffhunk://#diff-c4064ee3ef169ba4311917fde645bd2059c3a7185d4fd2fd1a22390cf77cef20L109-R135) [[3]](diffhunk://#diff-c4064ee3ef169ba4311917fde645bd2059c3a7185d4fd2fd1a22390cf77cef20L137-R162)

**Other Improvements:**

* Enhanced cache-busting: the cache-busting hash now covers all static JS files, not just `script.js`, to prevent stale modules after updates. [[1]](diffhunk://#diff-4c678463dd4ccd326b2c7812c92a377810f40479691125640b3ce2964c46e06eL44-R63) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR25-R28)
* Minor frontend update to support the new activation bar context menu.
<img width="353" height="434" alt="image" src="https://github.com/user-attachments/assets/b7e4de5f-922e-486d-ab1f-5aa91a9222ff" />
