### PR TITLE
Fix activity note context menu not closing

### DIFF
--- a/src/plantuml_gui/static/script.js
+++ b/src/plantuml_gui/static/script.js
@@ -472,7 +472,7 @@ function addActivityEventListeners() {
             'ellipse-menu',
             'if-menu',
             'fork-menu',
-            'seq-note-menu',
+            'note-menu',
             'group-menu',
             'merge-menu',
             'while-menu',

--- a/tests/e2e/test_activity_note_menu.py
+++ b/tests/e2e/test_activity_note_menu.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2026 Ericsson
+
+"""Regression test: the activity note context menu ('note-menu') must close
+on an outside click, same as the other activity context menus. It was
+previously mixed up with the sequence note menu id ('seq-note-menu') in the
+activity outside-click handler, so it never closed."""
+
+
+def test_activity_note_menu_closes_on_outside_click(app_url, page):
+    page.wait_for_timeout(1000)
+
+    menu_display_after_open, menu_display_after_outside_click = page.evaluate(
+        """() => {
+            const menu = document.getElementById('note-menu');
+            menu.style.display = 'block';
+            menu.style.left = '10px';
+            menu.style.top = '10px';
+            const afterOpen = menu.style.display;
+
+            document.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+
+            const afterOutsideClick = menu.style.display;
+            return [afterOpen, afterOutsideClick];
+        }"""
+    )
+
+    assert menu_display_after_open == "block"
+    assert menu_display_after_outside_click == "none"


### PR DESCRIPTION
The activity outside-click handler (addActivityEventListeners) listed 'seq-note-menu' instead of 'note-menu' when closing context menus, so the activity note context menu never closed on outside click. The two ids got mixed up between the sequence and activity note menus.