### PR TITLE
Fix/png download button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### External
 
+- Fixed the PNG toolbar button opening the rendered diagram in a new tab instead of downloading it; it now triggers a `diagram.png` file download, matching its "Download diagram as PNG" tooltip
 - Added a visible Import button in the code toolbar (left of the Download button, separated by a divider) to load a `.puml`/`.txt` file into the editor; previously this was only reachable via a hidden button. The Download button no longer uses the blue accent style, matching the other toolbar buttons
 - Fixed multi-line message text producing invalid PlantUML for sequence diagrams (newlines are now escaped as `\n` in the generated code)
 - Fixed multi-line note text producing invalid PlantUML for sequence diagrams (newlines are now escaped as `\n` in the generated code)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### External
 
+- Fixed downloaded PNG diagrams being low resolution and blurry: PlantUML's default PNG rasterization renders at ~96 DPI, so the exported image was much lower quality than the in-app SVG preview; PNG export now renders at 300 DPI (roughly 3x the pixel dimensions)
 - Fixed the PNG toolbar button opening the rendered diagram in a new tab instead of downloading it; it now triggers a `diagram.png` file download, matching its "Download diagram as PNG" tooltip
 - Added a visible Import button in the code toolbar (left of the Download button, separated by a divider) to load a `.puml`/`.txt` file into the editor; previously this was only reachable via a hidden button. The Download button no longer uses the blue accent style, matching the other toolbar buttons
 - Fixed multi-line message text producing invalid PlantUML for sequence diagrams (newlines are now escaped as `\n` in the generated code)

--- a/src/plantuml_gui/shared/render.py
+++ b/src/plantuml_gui/shared/render.py
@@ -69,6 +69,7 @@ def _create_png_from_uml(uml):
         os.environ["PLANTUML_JAR"],
         "-pipe",
         "-tpng",  # output in png format
+        "-Sdpi=300",  # render at higher resolution for crisper downloaded images
     ]
     process = run(
         base_command,

--- a/src/plantuml_gui/static/script.js
+++ b/src/plantuml_gui/static/script.js
@@ -318,6 +318,7 @@ function buttonEventListeners() {
             displayErrorMessage(`Error with fetch API: ${error.message}`, error);
         }
     })
+    // Download the diagram as a PNG file via a temporary download link.
     document.getElementById('png').addEventListener('click', async () => {
         try {
             const plantuml = trimlines(editor.session.getValue());
@@ -329,20 +330,14 @@ function buttonEventListeners() {
 
             const blob = await response.blob();
 
-            // Convert blob → base64 Data URL to make image copiable
-            const reader = new FileReader();
-            reader.onloadend = () => {
-                const imageUrl = reader.result; // data:image/png;base64,...
-
-                const newTab = window.open('', '_blank');
-                const img = newTab.document.createElement('img');
-                img.src = imageUrl;
-                newTab.document.body.appendChild(img);
-                newTab.document.body.style.textAlign = 'center';
-                newTab.document.close();
-            };
-
-            reader.readAsDataURL(blob);
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = "diagram.png";
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
 
         } catch (error) {
             displayErrorMessage(`Error with fetch API: ${error.message}`, error);

--- a/tests/e2e/test_ribbon.py
+++ b/tests/e2e/test_ribbon.py
@@ -142,6 +142,15 @@ def test_code_toolbar_import_button_loads_file(app_url, page):
     assert "foo -> bar" in content
 
 
+def test_diagram_toolbar_png_button_downloads_file(app_url, page):
+    """PNG button downloads the diagram as a file instead of opening a new tab."""
+    page.wait_for_timeout(1000)
+    with page.expect_download() as download_info:
+        page.locator("#png").click()
+    download = download_info.value
+    assert download.suggested_filename == "diagram.png"
+
+
 def test_zoom_in_increases_scale(app_url, page):
     """Clicking zoom in increases the panzoom scale."""
     page.wait_for_timeout(2000)

--- a/tests/shared/test_render.py
+++ b/tests/shared/test_render.py
@@ -25,6 +25,7 @@
 """Tests for SVG/PNG rendering and PlantUML URL encoding/decoding."""
 
 import re
+import struct
 
 from flask import json
 
@@ -34,6 +35,12 @@ def extract_g_element(svg_string):
     if match:
         return f"<g>{match.group(1)}</g>"
     return None
+
+
+def _png_size(png_bytes):
+    """Read the pixel width/height from a PNG's IHDR chunk."""
+    width, height = struct.unpack(">II", png_bytes[16:24])
+    return width, height
 
 
 class TestRender:
@@ -70,6 +77,13 @@ class TestRender:
 
             # Assert the Content-Type header is "image/png"
             assert response.content_type == "image/png"
+
+            # Assert the PNG is rendered at a higher resolution than
+            # PlantUML's low-res default (84x54 for this diagram at the
+            # default 96 DPI), so downloaded diagrams aren't blurry.
+            width, height = _png_size(response.data)
+            assert width > 150
+            assert height > 100
 
 
 class TestAppRouteEncodeDecode:


### PR DESCRIPTION
This pull request improves the quality and user experience of PNG diagram downloads and updates related tests to ensure these changes work as expected. The main changes include increasing the resolution of exported PNG images, updating the PNG download button to trigger a file download instead of opening a new tab, and adding tests to verify these behaviors.

**PNG Export Improvements**
- Increased the resolution of exported PNG diagrams by adding the `-Sdpi=300` option when rendering with PlantUML, resulting in much sharper images compared to the previous low-res default.
- Updated the PNG toolbar button so that clicking it downloads the diagram as a `diagram.png` file, matching the tooltip and improving usability, instead of opening the image in a new browser tab.

**Testing Enhancements**
- Added an end-to-end test to verify that clicking the PNG button triggers a file download named `diagram.png`.
- Added and used a helper function to extract PNG dimensions from image bytes, and updated the PNG rendering test to assert that the exported image is rendered at a higher resolution (width > 150px, height > 100px), ensuring the download is not blurry. [[1]](diffhunk://#diff-0667c60d6ffb66f4a9f70c6a9f83f607a33173cf8e99e339feda6c10a8faa505R40-R45) [[2]](diffhunk://#diff-0667c60d6ffb66f4a9f70c6a9f83f607a33173cf8e99e339feda6c10a8faa505R81-R87)

**Documentation**
- Updated the `CHANGELOG.md` with details about the improved PNG export resolution and the new download behavior.