### PR TITLE
Fix sequence message-to-line mapping for reverse & multi-line text

### DIFF
--- a/src/plantuml_gui/sequence/classes.py
+++ b/src/plantuml_gui/sequence/classes.py
@@ -33,6 +33,43 @@ from pyquery import PyQuery as Pq  # pragma: no cover
 # Matches the identification used by the frontend's checkIfParticipant.
 PARTICIPANT_RECT_STYLE = "stroke:#181818;stroke-width:0.5;"
 
+# A message arrow, matched so its optional embedded color bracket can be read or
+# rewritten. The arrow either starts with ``<`` (a reverse/bidirectional head)
+# or ends with a head (``>``, ``x`` or ``o``); either way it contains at least
+# one dash. Requiring a head keeps a lone ``-`` inside a participant name (e.g.
+# ``Web-Server``) from being mistaken for the arrow. An existing ``[#color]``
+# token may sit anywhere among the dashes.
+#
+# Lives here, in the base module, so both message parsing (index assignment,
+# below) and message.py's color read/rewrite share one arrow definition and
+# cannot drift apart. classes.py imports nothing from the package, so message.py
+# importing this back is cycle-free.
+ARROW_RE = re.compile(
+    r"<{1,2}[-\\/]*(?:\[#[^\]]*\])?[-\\/]*(?:>{1,2}|[xo])?"  # starts with '<'
+    r"|[-\\/]+(?:\[#[^\]]*\])?[-\\/]*(?:>{1,2}|[xo])"  # ends with a head
+)
+
+
+def is_message_line(line: str) -> bool:
+    """Return True if a puml line is a message (``sender <arrow> receiver: text``).
+
+    The arrow always precedes the ``": "`` text separator, so only the part
+    before the first colon is inspected. Reverse (``<-``), bidirectional
+    (``<->``), dotted, self, and colored (``-[#red]>``) arrows are all matched
+    via :data:`ARROW_RE`.
+
+    Requiring a real dash in the matched arrow rejects two look-alikes:
+    non-message lines whose free text happens to contain a ``<`` before a colon
+    (e.g. a group label ``alt <size:12>...``), which :data:`ARROW_RE` would
+    otherwise match as a bare ``<``; and notes/labels that carry their arrow
+    only after the colon.
+    """
+    colon_pos = line.find(":")
+    if colon_pos == -1:
+        return False
+    match = ARROW_RE.search(line[:colon_pos])
+    return match is not None and "-" in match.group(0)
+
 
 def is_participant_rect(rect: Pq) -> bool:
     """Return True if an SVG rect is a participant header (not an activation
@@ -296,23 +333,9 @@ class Diagram:
         """Assign indexes in the puml code to corresponding message"""
         lines = puml.splitlines()
 
-        def is_message_line(line: str) -> bool:
-            # A real message line is "sender -> receiver: text", so the
-            # arrow always precedes the colon. Notes/group labels can
-            # contain "->" in their free text, but only after (or without)
-            # a colon, since they aren't built with that arrow-then-colon
-            # shape.
-            #
-            # A colored arrow embeds a "[#color]" token between the dash and
-            # the head (e.g. "-[#red]>"), which would otherwise hide the
-            # "->" substring; strip such tokens first so colored messages are
-            # still recognized.
-            line = re.sub(r"\[#[^\]]*\]", "", line)
-            arrow_pos = line.find("->")
-            colon_pos = line.find(":")
-            return arrow_pos != -1 and colon_pos != -1 and arrow_pos < colon_pos
-
-        # Find all lines that represent messages (lines with '->' before ':')
+        # Find all lines that represent messages, in source order. This must
+        # count the same arrows the SVG parser does (both directions), or the
+        # message list and the source lines fall out of alignment.
         message_lines = [i for i, line in enumerate(lines) if is_message_line(line)]
 
         # Messages are already in occuring order

--- a/src/plantuml_gui/sequence/message.py
+++ b/src/plantuml_gui/sequence/message.py
@@ -27,7 +27,7 @@ from typing import Dict, List
 
 from pyquery import PyQuery as Pq
 
-from .classes import Diagram, Participant
+from .classes import ARROW_RE, Diagram, Participant
 from .util import (
     escape_multiline_text,
     find_insertion_index,
@@ -97,11 +97,28 @@ def _svg_element_matches(element: Pq, clicked: Pq) -> bool:
     return False
 
 
+def _is_continuation_text(element: Pq) -> bool:
+    """Return True if an SVG element is a message text continuation line.
+
+    A multi-line message (``A -> B: a\\nb``) renders its text as several
+    <text> siblings following the message's shape group. They are plain
+    message text (font-size 13, not bold - bold marks a group keyword/label)
+    and, unlike the group's first line, aren't part of any tag pattern, so
+    they must be explicitly attributed to their message.
+    """
+    if element[0].tag != "text":
+        return False
+    return element.attr("font-size") == "13" and element.attr("font-weight") != "bold"
+
+
 def index_of_clicked_message(svg: str, svgelement: str) -> int:
     """Find the 1-based index of the message containing the clicked SVG element.
 
     Iterates SVG elements using the same grouping logic as Diagram._parse_messages,
     checking if the clicked element matches any element in each message group.
+    Continuation text lines of a multi-line message (rendered as extra <text>
+    siblings after the group) are attributed to that same message, so a click on
+    any line of the text resolves to it.
     """
     d = Pq(svg)
     clicked = Pq(svgelement)
@@ -114,46 +131,42 @@ def index_of_clicked_message(svg: str, svgelement: str) -> int:
         tags = [el[0].tag for el in group]
 
         if tags[:4] == ["polygon", "polygon", "line", "text"]:
-            message_index += 1
-            for el in group[:4]:
-                if _svg_element_matches(el, clicked):
-                    return message_index
-            i += 4
+            members = list(group[:4])
+            j = i + 4
         elif tags[:5] == ["line", "line", "line", "polygon", "text"]:
-            message_index += 1
-            for el in group[:5]:
-                if _svg_element_matches(el, clicked):
-                    return message_index
-            i += 5
+            members = list(group[:5])
+            j = i + 5
         elif tags[:3] == ["polygon", "line", "text"]:
-            message_index += 1
-            for el in group[:3]:
-                if _svg_element_matches(el, clicked):
-                    return message_index
-            i += 3
+            members = list(group[:3])
+            j = i + 3
         else:
             i += 1
+            continue
+
+        message_index += 1
+        # Attribute any trailing continuation text lines to this message. The
+        # next message always starts with a polygon/line and a note with its
+        # shape, so a bare <text> here can only be this message's extra line.
+        while j < len(elements) and _is_continuation_text(elements[j]):
+            members.append(elements[j])
+            j += 1
+        for el in members:
+            if _svg_element_matches(el, clicked):
+                return message_index
+        i = j
 
     return -1
 
 
-# A message arrow, matched so its optional embedded color bracket can be read or
-# rewritten. The arrow either starts with ``<`` (a reverse/bidirectional head)
-# or ends with a head (``>``, ``x`` or ``o``); either way it contains at least
-# one dash. Requiring a head keeps a lone ``-`` inside a participant name (e.g.
-# ``Web-Server``) from being mistaken for the arrow. An existing ``[#color]``
-# token may sit anywhere among the dashes.
-_ARROW_RE = re.compile(
-    r"<{1,2}[-\\/]*(?:\[#[^\]]*\])?[-\\/]*(?:>{1,2}|[xo])?"  # starts with '<'
-    r"|[-\\/]+(?:\[#[^\]]*\])?[-\\/]*(?:>{1,2}|[xo])"  # ends with a head
-)
-
-
 def _arrow_color_from_line(line: str) -> str:
-    """Extract a message's arrow color from its puml line (``""`` if none)."""
+    """Extract a message's arrow color from its puml line (``""`` if none).
+
+    Uses the shared ``ARROW_RE`` (defined in ``classes.py``) so message-line
+    detection and color read/rewrite recognize the exact same arrow shapes.
+    """
     colon_pos = line.find(": ")
     prefix = line[:colon_pos] if colon_pos != -1 else line
-    match = _ARROW_RE.search(prefix)
+    match = ARROW_RE.search(prefix)
     if not match:
         return ""
     color_match = re.search(r"\[#([^\]]+)\]", match.group(0))
@@ -179,21 +192,25 @@ def _apply_arrow_color(arrow: str, color: str) -> str:
 
 def _set_arrow_color(prefix: str, color: str) -> str:
     """Rewrite the arrow color in a message line's pre-``": "`` prefix."""
-    match = _ARROW_RE.search(prefix)
+    match = ARROW_RE.search(prefix)
     if not match:
         return prefix
     new_arrow = _apply_arrow_color(match.group(0), color)
     return prefix[: match.start()] + new_arrow + prefix[match.end() :]
 
 
-def _clicked_message_line(puml: str, svg: str, svgelement: str) -> str:
-    """Return the puml source line of the clicked message.
+def _clicked_message_line(puml: str, svg: str, svgelement: str) -> str | None:
+    """Return the puml source line of the clicked message, or ``None``.
 
     Shared by the label/color getters so the SVG is parsed and the clicked
-    message resolved in one place.
+    message resolved in one place. Returns ``None`` when the clicked element
+    doesn't resolve to a message (``index_of_clicked_message`` returned -1), so
+    callers never index ``messages[-1 - 1]`` and read an unrelated message.
     """
     diagram = Diagram.from_svg(svg, puml)
     idx = index_of_clicked_message(svg, svgelement)
+    if idx == -1:
+        return None
     return puml.splitlines()[diagram.messages[idx - 1].index]
 
 
@@ -205,13 +222,15 @@ def _message_text_from_line(line: str) -> str:
 
 
 def get_message_text(puml: str, svg: str, svgelement: str) -> str:
-    """Get the label text of the clicked message."""
-    return _message_text_from_line(_clicked_message_line(puml, svg, svgelement))
+    """Get the label text of the clicked message (``""`` if not a message)."""
+    line = _clicked_message_line(puml, svg, svgelement)
+    return _message_text_from_line(line) if line is not None else ""
 
 
 def get_message_color(puml: str, svg: str, svgelement: str) -> str:
-    """Get the arrow color of the clicked message (``""`` if uncolored)."""
-    return _arrow_color_from_line(_clicked_message_line(puml, svg, svgelement))
+    """Get the arrow color of the clicked message (``""`` if uncolored/none)."""
+    line = _clicked_message_line(puml, svg, svgelement)
+    return _arrow_color_from_line(line) if line is not None else ""
 
 
 def get_message_label(puml: str, svg: str, svgelement: str) -> tuple[str, str]:
@@ -219,8 +238,11 @@ def get_message_label(puml: str, svg: str, svgelement: str) -> tuple[str, str]:
 
     Resolves the message's puml line once (parsing the SVG a single time) and
     derives both fields, so the /getMessageText route avoids a redundant parse.
+    Returns ``("", "")`` when the clicked element isn't a message.
     """
     line = _clicked_message_line(puml, svg, svgelement)
+    if line is None:
+        return "", ""
     return _message_text_from_line(line), _arrow_color_from_line(line)
 
 
@@ -235,6 +257,8 @@ def edit_message_text(
     """
     diagram = Diagram.from_svg(svg, puml)
     idx = index_of_clicked_message(svg, svgelement)
+    if idx == -1:
+        return puml  # clicked element isn't a message; leave puml unchanged
     message = diagram.messages[idx - 1]
     lines = puml.splitlines()
     line = lines[message.index]
@@ -251,9 +275,11 @@ def edit_message_text(
 
 
 def delete_message(puml: str, svg: str, svgelement: str) -> str:
-    """Delete the clicked message."""
+    """Delete the clicked message (no-op if the element isn't a message)."""
     diagram = Diagram.from_svg(svg, puml)
     idx = index_of_clicked_message(svg, svgelement)
+    if idx == -1:
+        return puml  # clicked element isn't a message; leave puml unchanged
     message = diagram.messages[idx - 1]
     lines = puml.splitlines()
     del lines[message.index]

--- a/tests/sequence/test_message_line_indexing.py
+++ b/tests/sequence/test_message_line_indexing.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2026 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Regression tests for message-line <-> source-line index mapping.
+
+Reverse arrows (``A <- B``, ``A <[#c]- B``) must be recognized as messages just
+like forward ones, so the SVG-parsed message list stays aligned with the puml
+source lines. A misalignment here silently breaks delete, editor<->diagram hover
+highlighting, and note insertion for any diagram containing a reverse arrow.
+
+These use the real PlantUML render (including ``!pragma teoz true``) so the
+alignment is validated against the exact SVG the app parses at runtime.
+"""
+
+import re
+
+import pytest
+from plantuml_gui.sequence.classes import Diagram, is_message_line
+from plantuml_gui.sequence.message import (
+    delete_message,
+    get_message_positions,
+)
+from plantuml_gui.sequence.note import add_note
+from plantuml_gui.shared.render import _create_svg_from_uml
+from pyquery import PyQuery as Pq
+
+# A diagram exercising every arrow direction the SVG parser counts: reverse
+# (``<-``), forward (``->``), colored reverse/forward (``<[#red]-`` /
+# ``-[#red]>``), a self message, and a dotted forward (``-->``). It also puts an
+# ``alt``/``else`` block around some messages, whose ``<size:12>`` labels contain
+# a ``<`` and a ``:`` and must NOT be miscounted as messages.
+PUML = """@startuml
+!pragma teoz true
+participant Access
+participant SMF
+participant PCF
+autonumber
+SMF<-PCF:R1
+SMF->PCF:R2
+SMF->Access:R3
+SMF<[#red]-PCF: R4
+SMF-[#red]>PCF: R5
+SMF<-Access:R6
+SMF -> SMF: 123
+SMF->PCF:R8
+SMF<-PCF:R9
+alt <size:12>a) Rule Update</size>
+SMF-[#red]>Access:R10
+SMF<[#red]-Access:R11
+else <size:12>b) Rule Remove</size>
+SMF --> Access: R12
+SMF-[#red]>Access:R13
+SMF<[#red]-Access:R14
+end
+@enduml"""
+
+# 0-based source-line index of every message line above, in source order.
+EXPECTED_MESSAGE_LINES = [6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 20, 21]
+
+
+def _svg_inner(puml):
+    """Render puml and return the inner content of the top-level <g> element.
+
+    Mirrors what the frontend posts back to the sequence routes (the SVG's
+    ``<g>`` innerHTML), so parsing matches runtime behavior.
+    """
+    svg = _create_svg_from_uml(puml)
+    return re.search(r"<g>(.*)</g>", svg, re.DOTALL).group(1)
+
+
+def _nth_message_element(svg_inner, message_index):
+    """Return the outerHTML of the <text> element of the nth message (0-based).
+
+    Uses the same element grouping as Diagram._parse_messages so the returned
+    element resolves back to that message via index_of_clicked_message.
+    """
+    d = Pq(svg_inner)
+    elements = list(d("*").items())
+    i = 0
+    count = 0
+    while i < len(elements):
+        group = elements[i : i + 5]
+        tags = [el[0].tag for el in group]
+        if tags[:4] == ["polygon", "polygon", "line", "text"]:
+            step, text = 4, group[3]
+        elif tags[:5] == ["line", "line", "line", "polygon", "text"]:
+            step, text = 5, group[4]
+        elif tags[:3] == ["polygon", "line", "text"]:
+            step, text = 3, group[2]
+        else:
+            i += 1
+            continue
+        if count == message_index:
+            return str(text)
+        count += 1
+        i += step
+    return None
+
+
+def test_reverse_and_colored_arrows_map_to_correct_source_lines():
+    """Every message (any direction) maps to its own puml source line."""
+    inner = _svg_inner(PUML)
+    diagram = Diagram.from_svg(inner, PUML)
+
+    assert len(diagram.messages) == len(EXPECTED_MESSAGE_LINES)
+    assert [m.index for m in diagram.messages] == EXPECTED_MESSAGE_LINES
+
+
+def test_delete_reverse_arrow_message_removes_that_line():
+    """Deleting a reverse-arrow message removes its own line, not another."""
+    inner = _svg_inner(PUML)
+    # 6th message (0-based index 5) is "SMF<-Access:R6", a reverse arrow.
+    element = _nth_message_element(inner, 5)
+    result = delete_message(PUML, inner, element)
+
+    assert "SMF<-Access:R6" not in result
+    # Neighbors must be untouched.
+    assert "SMF-[#red]>PCF: R5" in result
+    assert "SMF -> SMF: 123" in result
+
+
+def test_note_insertion_between_reverse_arrows_lands_at_correct_line():
+    """A note dropped between two messages is inserted between their lines."""
+    inner = _svg_inner(PUML)
+    positions = get_message_positions(PUML, inner)
+    # positions are in source order; [0] == R1 (reverse), [1] == R2.
+    y = (positions[0]["cy"] + positions[1]["cy"]) / 2
+
+    result = add_note(PUML, inner, "SMF", "over", "MYNOTE", y)
+    lines = result.splitlines()
+    note_line = next(i for i, ln in enumerate(lines) if "MYNOTE" in ln)
+    r1_line = next(i for i, ln in enumerate(lines) if "SMF<-PCF:R1" in ln)
+    r2_line = next(i for i, ln in enumerate(lines) if "SMF->PCF:R2" in ln)
+
+    assert r1_line < note_line < r2_line
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "A -> B: hi",  # forward
+        "A --> B: hi",  # dotted forward
+        "A ->> B: hi",  # thin forward
+        "A -x B: hi",  # lost-message head
+        "A <- B: hi",  # reverse
+        "A <-- B: hi",  # dotted reverse
+        "A <-> B: hi",  # bidirectional
+        "A -[#red]> B: hi",  # colored forward
+        "A <[#red]- B: hi",  # colored reverse
+        "A -> A: self",  # self message
+        "Web-Server -> Client: hi",  # dash in participant name
+    ],
+)
+def test_is_message_line_accepts_every_arrow_direction(line):
+    assert is_message_line(line) is True
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "alt <size:12>a) Rule Update</size>",  # group label: '<' before ':'
+        "else <size:12>b) Rule Remove</size>",
+        "note over A : some text",  # note, arrow only in free text
+        "note left of A : x -> y",  # arrow after the colon
+        "participant Access",
+        "autonumber",
+        "@startuml",
+        "end",
+        "group My Group",
+    ],
+)
+def test_is_message_line_rejects_non_messages(line):
+    assert is_message_line(line) is False

--- a/tests/sequence/test_message_multiline_click.py
+++ b/tests/sequence/test_message_multiline_click.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2026 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Regression tests for clicking multi-line message text and unmatched elements.
+
+A multi-line message (``A -> B: line1\\nline2``) renders its text as several
+<text> elements. Clicking any line must resolve to that message. A truly
+unmatched element must be a safe no-op, never a silent wrong-message edit/delete
+(the old code indexed ``messages[idx - 1]`` with ``idx == -1``, i.e.
+``messages[-2]``, deleting an unrelated message).
+"""
+
+import re
+
+from plantuml_gui.sequence.message import (
+    delete_message,
+    edit_message_text,
+    get_message_text,
+    index_of_clicked_message,
+)
+from plantuml_gui.shared.render import _create_svg_from_uml
+from pyquery import PyQuery as Pq
+
+# m2 has multi-line text; several messages follow so messages[-2] is a distinct,
+# recognizable line (the old bug deleted this one for any unmatched element).
+PUML = """@startuml
+participant Alice
+participant Bob
+participant Server
+Alice -> Bob: first
+Bob -> Server: line one\\nline two\\nline three
+Server -> Alice: third
+Alice -> Bob: fourth
+Alice -> Bob: WRONG_TARGET
+Alice -> Alice: last
+@enduml"""
+
+
+def _inner(puml):
+    svg = _create_svg_from_uml(puml)
+    return re.search(r"<g>(.*)</g>", svg, re.DOTALL).group(1)
+
+
+def _text_element(inner, contains):
+    for t in Pq(inner)("text").items():
+        if contains in (t.text() or ""):
+            return str(t)
+    return None
+
+
+def test_clicking_second_line_resolves_to_its_message():
+    inner = _inner(PUML)
+    second_line = _text_element(inner, "line two")
+    third_line = _text_element(inner, "line three")
+    assert second_line and third_line
+
+    # Both continuation lines resolve to message #2 (same as the first line).
+    assert index_of_clicked_message(inner, second_line) == 2
+    assert index_of_clicked_message(inner, third_line) == 2
+
+
+def test_delete_via_continuation_line_removes_that_message():
+    inner = _inner(PUML)
+    second_line = _text_element(inner, "line two")
+    result = delete_message(PUML, inner, second_line)
+
+    # The clicked message is removed; the old bug removed WRONG_TARGET instead.
+    assert "line one" not in result
+    assert "WRONG_TARGET" in result
+
+
+def test_edit_via_continuation_line_edits_that_message():
+    inner = _inner(PUML)
+    second_line = _text_element(inner, "line two")
+    result = edit_message_text(PUML, inner, second_line, "EDITED")
+
+    lines = result.splitlines()
+    edited = [ln for ln in lines if "EDITED" in ln]
+    assert edited and edited[0].startswith("Bob -> Server:")
+    assert "WRONG_TARGET" in result  # untouched
+
+
+def test_unmatched_element_is_a_safe_noop():
+    inner = _inner(PUML)
+    # A participant header rect is never a message; it must not match anything.
+    foreign = "<rect x='0' y='0' width='1' height='1' />"
+    assert index_of_clicked_message(inner, foreign) == -1
+    assert delete_message(PUML, inner, foreign) == PUML
+    assert edit_message_text(PUML, inner, foreign, "X") == PUML
+    assert get_message_text(PUML, inner, foreign) == ""

--- a/tests/sequence/test_reverse_arrow_routes.py
+++ b/tests/sequence/test_reverse_arrow_routes.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2026 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Full-stack regression for the reported reverse-arrow bug.
+
+Drives the real HTTP routes the frontend uses (``/render``,
+``/getSequencePositions``, ``/deleteMessage``) with the user's exact teoz
+diagram (nested boxes, ``...`` delay, colored reverse arrows). Confirms the
+message->source-line mapping that hover highlighting and delete depend on is
+correct end-to-end, so hovering/deleting ``SMF<-Access:CreateBearerResponse``
+resolves to its own line rather than an unrelated one.
+
+Deterministic on purpose: it uses the Flask test client and a single render,
+avoiding the browser render-race flakiness a live_server probe would add, while
+still exercising the full backend request path against real teoz-rendered SVG.
+"""
+
+import re
+
+from pyquery import PyQuery as Pq
+
+# The exact diagram from the bug report.
+PUML = """@startuml
+!pragma teoz true
+skinparam maxMessageSize 500
+
+box
+box
+participant Access
+end box
+participant SMF
+participant PCF
+end box
+autonumber
+SMF<-PCF:PcfEventNotificationPolicyUpdateRequest
+SMF->PCF:PcfEventNotificationPolicyUpdateResponse [NoContent (204)]
+SMF->Access:CreateBearerRequest
+SMF<[#red]-PCF:  <font color=red>PcfEventNotificationPolicyUpdateRequest\\n<font color=red>(RuleUpdate/Rule Remove)
+SMF-[#red]>PCF: <font color=red>PcfEventNotificationPolicyUpdateResponse [NoContent (204)]
+SMF<-Access:CreateBearerResponse
+SMF -> SMF: 123
+SMF->PCF:PolicyUpdateRequest (SRA)
+SMF<-PCF:PolicyUpdateResponse [NoContent (204)]
+
+alt <size:12>a) Rule Update</size>
+SMF-[#red]>Access:<font color=red>UpdateBearerRequest
+SMF<[#red]-Access:<font color=red>UpdateBearerResponse
+else <size:12>b) Rule Remove</size>
+SMF --> Access: test
+SMF-[#red]>Access:<font color=red>DeleteBearerRequest
+SMF<[#red]-Access:<font color=red>DeleteBearerResponse
+end
+@enduml"""
+
+# 0-based source-line index each of the 14 messages must map to, in order.
+EXPECTED_MESSAGE_LINES = [12, 13, 14, 15, 16, 17, 18, 19, 20, 23, 24, 26, 27, 28]
+
+
+def _render_inner(client):
+    """Render PUML via /render and return the top-level <g> innerHTML."""
+    resp = client.post("/render", json={"plantuml": PUML})
+    svg = resp.data.decode("utf-8")
+    return re.search(r"<g>(.*)</g>", svg, re.DOTALL).group(1)
+
+
+def _nth_message_text_element(svg_inner, message_index):
+    """Return the <text> outerHTML of the nth message group (0-based)."""
+    elements = list(Pq(svg_inner)("*").items())
+    i = 0
+    count = 0
+    while i < len(elements):
+        group = elements[i : i + 5]
+        tags = [el[0].tag for el in group]
+        if tags[:4] == ["polygon", "polygon", "line", "text"]:
+            step, text = 4, group[3]
+        elif tags[:5] == ["line", "line", "line", "polygon", "text"]:
+            step, text = 5, group[4]
+        elif tags[:3] == ["polygon", "line", "text"]:
+            step, text = 3, group[2]
+        else:
+            i += 1
+            continue
+        if count == message_index:
+            return str(text)
+        count += 1
+        i += step
+    return None
+
+
+def test_positions_map_every_message_to_its_own_line(client):
+    """/getSequencePositions returns a correct line index for every message."""
+    inner = _render_inner(client)
+    resp = client.post("/getSequencePositions", json={"plantuml": PUML, "svg": inner})
+    messages = resp.get_json()["messages"]
+
+    assert [m["index"] for m in messages] == EXPECTED_MESSAGE_LINES
+    # The reported hover case: the 6th message (SMF<-Access:CreateBearerResponse,
+    # 0-based index 5) maps to its own line, not the UpdateBearerRequest line it
+    # used to resolve to.
+    lines = PUML.splitlines()
+    assert lines[messages[5]["index"]] == "SMF<-Access:CreateBearerResponse"
+
+
+def test_delete_reverse_arrow_message_removes_its_own_line(client):
+    """/deleteMessage on a reverse arrow removes that line, not a neighbor."""
+    inner = _render_inner(client)
+    # 6th message (0-based 5) is the reverse arrow SMF<-Access:CreateBearerResponse.
+    element = _nth_message_text_element(inner, 5)
+    resp = client.post(
+        "/deleteMessage",
+        json={"plantuml": PUML, "svg": inner, "svgelement": element},
+    )
+    result = resp.get_json()["plantuml"]
+
+    assert "SMF<-Access:CreateBearerResponse" not in result
+    # Neighbours and the diagram frame are untouched.
+    assert "SMF -> SMF: 123" in result
+    assert "@enduml" in result
+    assert result.count("\n") == PUML.count("\n") - 1


### PR DESCRIPTION
Delete/edit/hover resolved the wrong message on sequence diagrams:

- Reverse arrows (<-, <[#color]-) were not counted as message lines (only the '->' substring was checked), so the SVG-parsed message list fell out of alignment with the puml source lines. Move the arrow regex into classes.py as a shared ARROW_RE and detect message lines with it (requiring a real dash so 'alt <size:12>...' labels aren't matched).

- Clicking a multi-line message's 2nd+ text line returned index -1, and the message ops then indexed messages[-2], silently deleting/editing an unrelated message. index_of_clicked_message now attributes continuation <text> lines to their message, and delete/edit/getters guard idx == -1.

Adds regression tests covering reverse/colored/self/dotted arrows, the alt/else label exclusion, multi-line continuation clicks, and unmatched elements (safe no-op).