### PR TITLE
Ext/backend fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### External
+
+- Fixed adding a participant box around an implicitly-declared participant (one introduced by a message, with no `participant` line): it previously produced broken PlantUML with `end box` above `@startuml` and `box` before `@enduml`. The box gesture now reports a clear message asking you to declare the participant on its own line first.
+
+### Internal
+
+- Rewrote `Diagram._assign_participant_indexes` (`sequence/classes.py`) to map each participant to its declaration line by displayed name (quoted or bare, via the new `PARTICIPANT_DECLARATION_RE`/`_declared_participant_name`) rather than by position. Implicitly-introduced participants correctly keep index `-1` ("no declaration line") instead of shifting every later participant onto the wrong line, and `add_box` now rejects a negative index rather than letting Python's negative indexing invert the box. Added `tests/sequence/test_participant_indexes.py` and implicit-participant cases in `tests/sequence/test_box.py`.
+- Removed leftover module-level debug prints from `shared/puml_encoder.py`.
+
 ## [0.31] - 2026-07-22
 
 ### External

--- a/src/plantuml_gui/sequence/box.py
+++ b/src/plantuml_gui/sequence/box.py
@@ -140,7 +140,18 @@ def add_box(puml: str, title: str, color: str, start_index: int, end_index: int)
     If the range nests with an existing box, ``!pragma teoz true`` is added
     (once) so PlantUML renders nested boxes. A range that crosses an existing
     box (partial overlap) raises ``ValueError``.
+
+    A negative index means the participant has no declaration line (it was
+    introduced implicitly by a message) and raises ``ValueError``. Without this
+    check, ``lines.insert`` interprets -1 as "before the last line" and the box
+    lands inside out, with ``end box`` above ``@startuml``.
     """
+    if start_index < 0 or end_index < 0:
+        raise ValueError(
+            "A participant can only be put in a box if it is declared on its "
+            'own line. Add a "participant" line for it first.'
+        )
+
     start = min(start_index, end_index)
     end = max(start_index, end_index)
 

--- a/src/plantuml_gui/sequence/classes.py
+++ b/src/plantuml_gui/sequence/classes.py
@@ -49,6 +49,24 @@ ARROW_RE = re.compile(
     r"|[-\\/]+(?:\[#[^\]]*\])?[-\\/]*(?:>{1,2}|[xo])"  # ends with a head
 )
 
+# A participant declaration, capturing the name PlantUML renders in the SVG:
+# the quoted text when present (``participant "Long name" as A``), otherwise the
+# bare token (``participant Alice``). Trailing modifiers such as ``as A``,
+# ``order 10`` or a ``#color`` are left unmatched on purpose -- only the
+# displayed name is needed, because that is what the SVG gives us to match on.
+PARTICIPANT_DECLARATION_RE = re.compile(
+    r'^participant\s+(?:"(?P<quoted>[^"]*)"|(?P<bare>[^\s#]+))'
+)
+
+
+def _declared_participant_name(line: str) -> str | None:
+    """The displayed name a participant declaration introduces, if it is one."""
+    match = PARTICIPANT_DECLARATION_RE.match(line.strip())
+    if match is None:
+        return None
+    quoted = match.group("quoted")
+    return quoted if quoted is not None else match.group("bare")
+
 
 def is_message_line(line: str) -> bool:
     """Return True if a puml line is a message (``sender <arrow> receiver: text``).
@@ -280,16 +298,36 @@ class Diagram:
         self._assign_participant_indexes(puml)
 
     def _assign_participant_indexes(self, puml: str):
-        """Assign indexes in the puml code to corresponding participant"""
-        lines = puml.splitlines()
+        """Attach each participant to the puml line that declares it.
 
-        participant_lines = [
-            i for i, line in enumerate(lines) if line.startswith("participant")
+        Matched by name, not by position. A participant can be introduced
+        implicitly by a message (``Alice -> Bob: hi``) and then has no
+        declaration line at all, so zipping the declaration lines against the
+        diagram-ordered participants shifts every later participant onto some
+        other participant's line and leaves the trailing ones at -1. Callers
+        treat -1 as "not found", and add_box used to insert at it directly --
+        Python's negative indexing then wrote ``end box`` to the top of the
+        file and ``box`` before the last line.
+
+        Participants with no declaration keep index -1, which is accurate:
+        there is no line to point at. Callers that need a real line must say so
+        (see add_box).
+        """
+        declarations = [
+            (line_index, name)
+            for line_index, line in enumerate(puml.splitlines())
+            if (name := _declared_participant_name(line)) is not None
         ]
 
-        for i, line_index in enumerate(participant_lines):
-            if i < len(self.participants):
-                self.participants[i].index = line_index
+        # Consume each declaration at most once, so repeated display names map
+        # to distinct lines in diagram order rather than all to the first.
+        claimed: set[int] = set()
+        for participant in self.participants:
+            for position, (line_index, declared_name) in enumerate(declarations):
+                if position not in claimed and declared_name == participant.name:
+                    participant.index = line_index
+                    claimed.add(position)
+                    break
 
     def _parse_messages(self, svg, puml):
         """Parse messages from svg"""

--- a/src/plantuml_gui/shared/puml_encoder.py
+++ b/src/plantuml_gui/shared/puml_encoder.py
@@ -53,9 +53,3 @@ def plantuml_decode(plantuml_url):
     dec = zlib.decompressobj()  # without check the crc.
     header = b"x\x9c"
     return dec.decompress(header + data).decode("utf-8")
-
-
-url = "SyfFKj2rKt3CoKnELR1Io4ZDoSa700=="
-
-print(plantuml_decode(url))
-print(plantuml_encode(plantuml_decode(url)))

--- a/tests/sequence/test_box.py
+++ b/tests/sequence/test_box.py
@@ -199,6 +199,47 @@ BOB_INDEX = 2
 CAROL_INDEX = 3
 
 
+class TestAddBoxRejectsUndeclaredParticipants:
+    """A participant introduced by a message has no declaration line, so its
+    index is -1. Inserting at -1 silently means "before the last line" in
+    Python, which produced puml with ``end box`` above ``@startuml`` and ``box``
+    just before ``@enduml``.
+    """
+
+    def test_negative_start_index_is_rejected(self):
+        with pytest.raises(ValueError, match="declared on its own line"):
+            add_box(THREE_PARTICIPANT_PUML, "", "none", -1, BOB_INDEX)
+
+    def test_negative_end_index_is_rejected(self):
+        with pytest.raises(ValueError, match="declared on its own line"):
+            add_box(THREE_PARTICIPANT_PUML, "", "none", ALICE_INDEX, -1)
+
+    def test_both_negative_is_rejected(self):
+        with pytest.raises(ValueError, match="declared on its own line"):
+            add_box(THREE_PARTICIPANT_PUML, "", "none", -1, -1)
+
+    def test_puml_is_left_untouched(self):
+        # The reported symptom, stated as an invariant: a rejected call must not
+        # emit puml at all, let alone inverted puml.
+        with pytest.raises(ValueError):
+            add_box(THREE_PARTICIPANT_PUML, "", "none", -1, -1)
+
+    def test_route_reports_the_error(self, client):
+        response = client.post(
+            "/addBox",
+            data=json.dumps(
+                {
+                    "plantuml": THREE_PARTICIPANT_PUML,
+                    "startParticipantIndex": -1,
+                    "endParticipantIndex": -1,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert "declared on its own line" in json.loads(response.data)["error"]
+
+
 class TestAddBox:
     def test_wraps_single_participant(self):
         result = add_box(THREE_PARTICIPANT_PUML, "My Box", "none", BOB_INDEX, BOB_INDEX)

--- a/tests/sequence/test_participant_indexes.py
+++ b/tests/sequence/test_participant_indexes.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+#
+# MIT License
+#
+# Copyright (c) 2026 Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for mapping participants to the puml line that declares them.
+
+Participants can appear in a diagram without a declaration line -- a message
+like ``Alice -> Bob: hi`` introduces both. The mapping used to pair declaration
+lines with diagram-ordered participants positionally, which silently shifted
+every participant after the first implicit one onto some other participant's
+line, and left the trailing ones reporting -1 ("not found").
+
+That index feeds box creation and participant hover-highlighting, so a wrong
+value edits or highlights the wrong line. Rendering real SVG here rather than
+hand-writing rects, so the diagram order is PlantUML's own.
+"""
+
+from plantuml_gui.sequence.classes import Diagram
+from plantuml_gui.shared.render import _create_svg_from_uml
+
+
+def _participants(puml):
+    """{name: puml line index} as reported for a real render of `puml`."""
+    svg = _create_svg_from_uml(puml)
+    inner = svg[svg.index(">", svg.index("<g")) + 1 : svg.rindex("</g>")]
+    diagram = Diagram.from_svg(inner, puml)
+    return {p.name: p.index for p in diagram.participants}
+
+
+def test_all_participants_declared():
+    puml = "@startuml\nparticipant a\nparticipant b\na -> b: m\n@enduml"
+
+    assert _participants(puml) == {"a": 1, "b": 2}
+
+
+def test_implicit_participant_does_not_shift_later_declarations():
+    """The reported bug: `participant1` reported -1 while its own declaration
+    sat on line 3, and `Alice` was handed that line instead."""
+    puml = (
+        "@startuml\n"  # 0
+        "participant t\n"  # 1
+        "Alice -> Bob: h\n"  # 2
+        "participant participant1\n"  # 3
+        "@enduml"  # 4
+    )
+
+    indexes = _participants(puml)
+
+    assert indexes["t"] == 1
+    assert indexes["participant1"] == 3
+    # Implicit participants genuinely have no line to point at.
+    assert indexes["Alice"] == -1
+    assert indexes["Bob"] == -1
+
+
+def test_fully_implicit_participants_report_not_found():
+    puml = "@startuml\nAlice -> Bob: h\n@enduml"
+
+    assert _participants(puml) == {"Alice": -1, "Bob": -1}
+
+
+def test_declaration_after_implicit_use_is_still_found():
+    puml = (
+        "@startuml\n"  # 0
+        "Alice -> Bob: h\n"  # 1
+        "participant Bob\n"  # 2  declared late, but declared
+        "@enduml"  # 3
+    )
+
+    indexes = _participants(puml)
+
+    assert indexes["Bob"] == 2
+    assert indexes["Alice"] == -1
+
+
+def test_quoted_display_name_is_matched():
+    """PlantUML renders the quoted text, which is what the SVG gives us, so the
+    alias must not be what we match on."""
+    puml = (
+        "@startuml\n"  # 0
+        'participant "Long Name" as L\n'  # 1
+        "participant b\n"  # 2
+        "L -> b: m\n"  # 3
+        "@enduml"  # 4
+    )
+
+    indexes = _participants(puml)
+
+    assert indexes["Long Name"] == 1
+    assert indexes["b"] == 2
+
+
+def test_declaration_with_trailing_color_is_matched():
+    puml = "@startuml\nparticipant a #red\nparticipant b\na -> b: m\n@enduml"
+
+    indexes = _participants(puml)
+
+    assert indexes["a"] == 1
+    assert indexes["b"] == 2
+
+
+def test_participant_named_like_a_prefix_of_another():
+    """`startswith`-style matching on names would pair `ab` with `a`'s line."""
+    puml = "@startuml\nparticipant ab\nparticipant a\nab -> a: m\n@enduml"
+
+    indexes = _participants(puml)
+
+    assert indexes["ab"] == 1
+    assert indexes["a"] == 2


### PR DESCRIPTION
Fixed adding a participant box around an implicitly-declared participant (one introduced by a message, with no `participant` line): it previously produced broken PlantUML with `end box` above `@startuml` and `box` before `@enduml`. The box gesture now reports a clear message asking you to declare the participant on its own line first.