### PR TITLE
Add the Node-side sidecar spawner for the backend server

### DIFF
--- a/plantuml-extension/src/sidecar.js
+++ b/plantuml-extension/src/sidecar.js
@@ -1,0 +1,373 @@
+// Lifecycle for the Python sidecar: the existing Flask app, run as a child
+// process on an ephemeral loopback port.
+//
+// The ~71 routes that rewrite PlantUML source live in Python
+// (src/plantuml_gui/), and reimplementing them in JavaScript would fork ~4,500
+// lines plus their test suite. Instead the extension spawns
+// `python -m plantuml_gui.serve` (see src/plantuml_gui/serve.py) and the
+// webview POSTs to it directly, so the web app's frontend code can be reused
+// with only its relative URLs rewritten.
+//
+// See docs/vscode_extension_interactivity.md.
+
+const { spawn } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const vscode = require('vscode');
+
+// Must match PORT_LINE_PREFIX in src/plantuml_gui/serve.py.
+const PORT_LINE_PREFIX = 'PLANTUML_GUI_PORT=';
+
+// The sidecar has to boot Python, import Flask, and bind a socket. Slow on a
+// cold filesystem or with an antivirus scanning the interpreter.
+const STARTUP_TIMEOUT_MS = 30000;
+
+const HEALTH_TIMEOUT_MS = 2000;
+
+/** Thrown when the sidecar cannot be started or does not become ready. */
+class SidecarStartError extends Error {}
+
+/**
+ * A running sidecar: the child process plus the address and token needed to
+ * talk to it.
+ */
+class Sidecar {
+	/**
+	 * @param {import('child_process').ChildProcess} process
+	 * @param {number} port
+	 * @param {string} token
+	 */
+	constructor(process, port, token) {
+		this.process = process;
+		this.port = port;
+		this.token = token;
+		this.baseUrl = `http://127.0.0.1:${port}/`;
+	}
+
+	/** @returns {boolean} whether the child is still running. */
+	get isRunning() {
+		return this.process.exitCode === null && this.process.signalCode === null;
+	}
+
+	dispose() {
+		if (this.isRunning) {
+			this.process.kill();
+		}
+	}
+}
+
+/**
+ * Ask the Python extension which interpreter the user has selected.
+ *
+ * Most people who have a virtualenv have already picked it there, so this
+ * spares them configuring the same path twice. The API has changed shape
+ * across versions, so every step is defensive: any failure just means we fall
+ * through to the next candidate.
+ *
+ * @returns {Promise<string|undefined>} an interpreter path, if one is selected.
+ */
+async function pythonExtensionInterpreter() {
+	try {
+		const extension = vscode.extensions.getExtension('ms-python.python');
+		if (!extension) {
+			return undefined;
+		}
+
+		const api = extension.isActive ? extension.exports : await extension.activate();
+		const environments = api?.environments;
+		if (!environments) {
+			return undefined;
+		}
+
+		const active = environments.getActiveEnvironmentPath?.();
+		if (!active) {
+			return undefined;
+		}
+
+		// `path` may be an env folder rather than the executable, so prefer the
+		// resolved executable when the API can give us one.
+		const resolved = await environments.resolveEnvironment?.(active);
+		const executable = resolved?.executable?.uri?.fsPath;
+
+		return executable || active.path || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Look for a virtualenv in the open workspace folders.
+ *
+ * @returns {string|undefined} the venv interpreter, if one exists on disk.
+ */
+function workspaceVenvInterpreter() {
+	const relative =
+		process.platform === 'win32'
+			? ['.venv', 'Scripts', 'python.exe']
+			: ['.venv', 'bin', 'python'];
+
+	for (const folder of vscode.workspace.workspaceFolders ?? []) {
+		const candidate = path.join(folder.uri.fsPath, ...relative);
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Resolve the Python interpreter to run the sidecar with.
+ *
+ * Tried in order, most explicit first. Requiring the user to hand-configure a
+ * path is the main friction in the sidecar design, so the fallbacks matter:
+ * note in particular that when the Extension Development Host launches without
+ * a folder, workspace-scoped settings are not read at all, and only the
+ * environment variable and the last-resort name are available.
+ *
+ * @returns {Promise<string>} an interpreter path or bare command name.
+ */
+async function resolvePythonPath() {
+	const configured = vscode.workspace
+		.getConfiguration('plantumlInteractive')
+		.get('pythonPath');
+
+	// An explicit setting wins even if it is wrong: a clear "could not run X"
+	// beats silently running some other interpreter than the one asked for.
+	if (configured) {
+		return configured;
+	}
+
+	// Lets launch.json configure development without a workspace folder,
+	// mirroring how it already passes PLANTUML_JAR.
+	if (process.env.PLANTUML_GUI_PYTHON) {
+		return process.env.PLANTUML_GUI_PYTHON;
+	}
+
+	return (
+		(await pythonExtensionInterpreter()) ??
+		workspaceVenvInterpreter() ??
+		(process.platform === 'win32' ? 'python' : 'python3')
+	);
+}
+
+/**
+ * Build the environment for the child process.
+ *
+ * The jar is passed as PLANTUML_GUI_JAR_OVERRIDE rather than PLANTUML_JAR
+ * because shared/render.py calls load_dotenv(override=True) at import time, so
+ * a repo-root .env would otherwise beat anything we set here. serve.py applies
+ * the override after that import. See apply_jar_override there.
+ *
+ * @param {string} token
+ * @param {string|undefined} jarPath
+ * @returns {NodeJS.ProcessEnv}
+ */
+function buildEnv(token, jarPath) {
+	const env = { ...process.env, PLANTUML_GUI_TOKEN: token };
+
+	if (jarPath) {
+		env.PLANTUML_GUI_JAR_OVERRIDE = jarPath;
+	}
+
+	// Unbuffered, so the port line reaches us as soon as it is printed rather
+	// than sitting in Python's block buffer (stdout is a pipe, not a tty).
+	env.PYTHONUNBUFFERED = '1';
+
+	return env;
+}
+
+/**
+ * Turn a failure to spawn or boot into a message that says what to install.
+ *
+ * @param {string} pythonPath
+ * @param {string} stderr
+ * @param {Error|undefined} spawnError
+ * @returns {string}
+ */
+function describeStartFailure(pythonPath, stderr, spawnError) {
+	if (spawnError && spawnError.code === 'ENOENT') {
+		return (
+			`Could not run Python at "${pythonPath}". Set ` +
+			'"plantumlInteractive.pythonPath" in your USER settings to an interpreter ' +
+			'that has the plantuml-gui package installed. (Workspace settings are ' +
+			'not read when the Extension Development Host is launched without a ' +
+			'folder open - during development, set PLANTUML_GUI_PYTHON in the "env" ' +
+			'block of launch.json instead.)'
+		);
+	}
+
+	if (/No module named ['"]?plantuml_gui/.test(stderr)) {
+		return (
+			`Python at "${pythonPath}" does not have the plantuml-gui package. ` +
+			'Install it into that interpreter, e.g. "pip install -e ." from the ' +
+			'repository root.'
+		);
+	}
+
+	const detail = stderr.trim();
+	return (
+		'The PlantUML backend failed to start.' + (detail ? `\n\n${detail}` : '')
+	);
+}
+
+/**
+ * Wait until the sidecar answers /health, so callers never send a real request
+ * to a socket that is bound but not yet serving.
+ *
+ * @param {Sidecar} sidecar
+ * @param {number} deadline epoch ms after which to give up
+ */
+async function waitForHealthy(sidecar, deadline) {
+	let lastError;
+
+	while (Date.now() < deadline) {
+		if (!sidecar.isRunning) {
+			throw new SidecarStartError('The PlantUML backend exited during startup.');
+		}
+
+		try {
+			const response = await fetch(`${sidecar.baseUrl}health`, {
+				headers: { 'X-PlantUML-Token': sidecar.token },
+				signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS)
+			});
+			if (response.ok) {
+				return;
+			}
+			lastError = new Error(`/health returned ${response.status}`);
+		} catch (err) {
+			lastError = err;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+
+	throw new SidecarStartError(
+		`The PlantUML backend did not become ready within ${STARTUP_TIMEOUT_MS}ms.` +
+			(lastError ? ` Last error: ${lastError.message}` : '')
+	);
+}
+
+/**
+ * Start the sidecar and wait until it is serving.
+ *
+ * @param {object} [options]
+ * @param {string} [options.jarPath] absolute path to plantuml.jar
+ * @param {vscode.OutputChannel} [options.output] receives sidecar stderr, so
+ *   Python tracebacks are visible instead of being swallowed
+ * @returns {Promise<Sidecar>}
+ * @throws {SidecarStartError}
+ */
+async function startSidecar(options = {}) {
+	const { jarPath, output } = options;
+	const pythonPath = await resolvePythonPath();
+	output?.appendLine(`Starting PlantUML backend with interpreter: ${pythonPath}`);
+	// Per-launch secret: this is an HTTP server on loopback, which any local
+	// process can reach, and every route rewrites the user's source.
+	const token = crypto.randomBytes(24).toString('hex');
+
+	const child = spawn(pythonPath, ['-m', 'plantuml_gui.serve'], {
+		env: buildEnv(token, jarPath)
+	});
+
+	let stderr = '';
+	child.stderr.setEncoding('utf-8');
+	child.stderr.on('data', (chunk) => {
+		// Cap what we retain: werkzeug logs every request here for the life of
+		// the process, so this would otherwise grow without bound.
+		stderr = (stderr + chunk).slice(-8000);
+		if (output) {
+			output.append(chunk);
+		}
+	});
+
+	const port = await readPortLine(child, pythonPath, () => stderr);
+	const sidecar = new Sidecar(child, port, token);
+
+	await waitForHealthy(sidecar, Date.now() + STARTUP_TIMEOUT_MS);
+
+	return sidecar;
+}
+
+/**
+ * Read the port the sidecar bound to off its stdout.
+ *
+ * Scans for the prefix rather than reading the first line: anything printed
+ * during import would otherwise be mistaken for the port line.
+ *
+ * @param {import('child_process').ChildProcess} child
+ * @param {string} pythonPath
+ * @param {() => string} getStderr
+ * @returns {Promise<number>}
+ */
+function readPortLine(child, pythonPath, getStderr) {
+	return new Promise((resolve, reject) => {
+		let buffered = '';
+		let settled = false;
+
+		const finish = (fn, arg) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			fn(arg);
+		};
+
+		const timer = setTimeout(() => {
+			child.kill();
+			finish(
+				reject,
+				new SidecarStartError(
+					`The PlantUML backend did not report a port within ${STARTUP_TIMEOUT_MS}ms.`
+				)
+			);
+		}, STARTUP_TIMEOUT_MS);
+
+		child.stdout.setEncoding('utf-8');
+		child.stdout.on('data', (chunk) => {
+			buffered += chunk;
+
+			// Only complete lines: a chunk boundary can fall mid-number.
+			const lines = buffered.split('\n');
+			buffered = lines.pop() ?? '';
+
+			for (const line of lines) {
+				if (line.startsWith(PORT_LINE_PREFIX)) {
+					const port = Number.parseInt(line.slice(PORT_LINE_PREFIX.length), 10);
+					if (Number.isInteger(port) && port > 0) {
+						finish(resolve, port);
+						return;
+					}
+				}
+			}
+		});
+
+		child.on('error', (err) => {
+			finish(
+				reject,
+				new SidecarStartError(describeStartFailure(pythonPath, getStderr(), err))
+			);
+		});
+
+		child.on('exit', (code) => {
+			finish(
+				reject,
+				new SidecarStartError(
+					describeStartFailure(pythonPath, getStderr(), undefined) +
+						`\n\n(exit code ${code})`
+				)
+			);
+		});
+	});
+}
+
+module.exports = {
+	startSidecar,
+	resolvePythonPath,
+	buildEnv,
+	describeStartFailure,
+	readPortLine,
+	Sidecar,
+	SidecarStartError,
+	PORT_LINE_PREFIX
+};

--- a/plantuml-extension/src/sidecar.js
+++ b/plantuml-extension/src/sidecar.js
@@ -1,3 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+// MIT License
+
+// Copyright (c) 2026 Ericsson
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 // Lifecycle for the Python sidecar: the existing Flask app, run as a child
 // process on an ephemeral loopback port.
 //

--- a/plantuml-extension/src/sidecar.js
+++ b/plantuml-extension/src/sidecar.js
@@ -12,8 +12,6 @@
 
 const { spawn } = require('child_process');
 const crypto = require('crypto');
-const fs = require('fs');
-const path = require('path');
 const vscode = require('vscode');
 
 // Must match PORT_LINE_PREFIX in src/plantuml_gui/serve.py.
@@ -58,75 +56,21 @@ class Sidecar {
 }
 
 /**
- * Ask the Python extension which interpreter the user has selected.
- *
- * Most people who have a virtualenv have already picked it there, so this
- * spares them configuring the same path twice. The API has changed shape
- * across versions, so every step is defensive: any failure just means we fall
- * through to the next candidate.
- *
- * @returns {Promise<string|undefined>} an interpreter path, if one is selected.
- */
-async function pythonExtensionInterpreter() {
-	try {
-		const extension = vscode.extensions.getExtension('ms-python.python');
-		if (!extension) {
-			return undefined;
-		}
-
-		const api = extension.isActive ? extension.exports : await extension.activate();
-		const environments = api?.environments;
-		if (!environments) {
-			return undefined;
-		}
-
-		const active = environments.getActiveEnvironmentPath?.();
-		if (!active) {
-			return undefined;
-		}
-
-		// `path` may be an env folder rather than the executable, so prefer the
-		// resolved executable when the API can give us one.
-		const resolved = await environments.resolveEnvironment?.(active);
-		const executable = resolved?.executable?.uri?.fsPath;
-
-		return executable || active.path || undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-/**
- * Look for a virtualenv in the open workspace folders.
- *
- * @returns {string|undefined} the venv interpreter, if one exists on disk.
- */
-function workspaceVenvInterpreter() {
-	const relative =
-		process.platform === 'win32'
-			? ['.venv', 'Scripts', 'python.exe']
-			: ['.venv', 'bin', 'python'];
-
-	for (const folder of vscode.workspace.workspaceFolders ?? []) {
-		const candidate = path.join(folder.uri.fsPath, ...relative);
-		if (fs.existsSync(candidate)) {
-			return candidate;
-		}
-	}
-
-	return undefined;
-}
-
-/**
  * Resolve the Python interpreter to run the sidecar with.
  *
- * Tried in order, most explicit first. Requiring the user to hand-configure a
- * path is the main friction in the sidecar design, so the fallbacks matter:
- * note in particular that when the Extension Development Host launches without
- * a folder, workspace-scoped settings are not read at all, and only the
- * environment variable and the last-resort name are available.
+ * Two explicit sources only, most explicit first. Nothing is guessed: the
+ * backend is a Python package that no machine has by default, so an
+ * interpreter found by searching is one that almost certainly cannot import
+ * plantuml_gui, and spawning it would report the failure against the wrong
+ * thing. Failing here names the knob to turn instead.
  *
- * @returns {Promise<string>} an interpreter path or bare command name.
+ * Note that the Extension Development Host launches **without a workspace
+ * folder**, so workspace-scoped settings are not read at all. During
+ * development, PLANTUML_GUI_PYTHON in the `env` block of .vscode/launch.json is
+ * the reliable knob.
+ *
+ * @returns {Promise<string>} an interpreter path.
+ * @throws {SidecarStartError} when no interpreter has been configured
  */
 async function resolvePythonPath() {
 	const configured = vscode.workspace
@@ -136,7 +80,7 @@ async function resolvePythonPath() {
 	// An explicit setting wins even if it is wrong: a clear "could not run X"
 	// beats silently running some other interpreter than the one asked for.
 	if (configured) {
-		return configured;
+		return /** @type {string} */ (configured);
 	}
 
 	// Lets launch.json configure development without a workspace folder,
@@ -145,10 +89,11 @@ async function resolvePythonPath() {
 		return process.env.PLANTUML_GUI_PYTHON;
 	}
 
-	return (
-		(await pythonExtensionInterpreter()) ??
-		workspaceVenvInterpreter() ??
-		(process.platform === 'win32' ? 'python' : 'python3')
+	throw new SidecarStartError(
+		'No Python interpreter is configured for the PlantUML backend. Set ' +
+			'"plantumlInteractive.pythonPath" to an interpreter that has the ' +
+			'plantuml-gui package installed, or set PLANTUML_GUI_PYTHON (during ' +
+			'development, in the "env" block of .vscode/launch.json).'
 	);
 }
 

--- a/plantuml-extension/test/sidecar.test.js
+++ b/plantuml-extension/test/sidecar.test.js
@@ -1,0 +1,183 @@
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { PassThrough } = require('stream');
+
+const {
+	buildEnv,
+	describeStartFailure,
+	readPortLine,
+	resolvePythonPath,
+	PORT_LINE_PREFIX
+} = require('../src/sidecar');
+
+/** A stand-in for a spawned child process, so the port handshake can be
+ * driven deterministically without launching Python. */
+function fakeChild() {
+	const child = new EventEmitter();
+	child.stdout = new PassThrough();
+	child.stderr = new PassThrough();
+	child.kill = () => {
+		child.killed = true;
+	};
+	return child;
+}
+
+suite('sidecar: environment', () => {
+	test('passes the jar as an override, not as PLANTUML_JAR', () => {
+		// shared/render.py calls load_dotenv(override=True) at import time, so
+		// setting PLANTUML_JAR here would be silently beaten by a repo .env.
+		const env = buildEnv('tok', '/path/to/plantuml.jar');
+
+		assert.strictEqual(env.PLANTUML_GUI_JAR_OVERRIDE, '/path/to/plantuml.jar');
+		assert.strictEqual(env.PLANTUML_GUI_TOKEN, 'tok');
+	});
+
+	test('omits the override when no jar is configured', () => {
+		const env = buildEnv('tok', undefined);
+
+		assert.ok(!('PLANTUML_GUI_JAR_OVERRIDE' in env));
+	});
+
+	test('disables Python output buffering', () => {
+		// Without this the port line can sit in a block buffer, since stdout
+		// is a pipe rather than a tty, and startup appears to hang.
+		assert.strictEqual(buildEnv('tok').PYTHONUNBUFFERED, '1');
+	});
+});
+
+suite('sidecar: interpreter resolution', () => {
+	const original = process.env.PLANTUML_GUI_PYTHON;
+
+	teardown(() => {
+		if (original === undefined) {
+			delete process.env.PLANTUML_GUI_PYTHON;
+		} else {
+			process.env.PLANTUML_GUI_PYTHON = original;
+		}
+	});
+
+	test('honours PLANTUML_GUI_PYTHON', async () => {
+		// The Extension Development Host launches with no folder open, so
+		// workspace settings are not read; the env var is how launch.json
+		// configures development.
+		process.env.PLANTUML_GUI_PYTHON = '/custom/python';
+
+		assert.strictEqual(await resolvePythonPath(), '/custom/python');
+	});
+
+	test('falls back to a platform-appropriate command', async () => {
+		delete process.env.PLANTUML_GUI_PYTHON;
+
+		const resolved = await resolvePythonPath();
+
+		// With no setting, no env var, and (in the test host) no Python
+		// extension or workspace venv, this is the last resort.
+		assert.ok(
+			resolved === 'python' || resolved === 'python3' || require('fs').existsSync(resolved),
+			`unexpected interpreter: ${resolved}`
+		);
+	});
+});
+
+suite('sidecar: startup failure messages', () => {
+	test('a missing interpreter names the setting to fix', () => {
+		const message = describeStartFailure('py3', '', { code: 'ENOENT' });
+
+		assert.ok(message.includes('py3'));
+		assert.ok(message.includes('plantumlInteractive.pythonPath'));
+	});
+
+	test('a missing package says how to install it', () => {
+		const message = describeStartFailure(
+			'python',
+			"ModuleNotFoundError: No module named 'plantuml_gui'",
+			undefined
+		);
+
+		assert.ok(message.includes('plantuml-gui'));
+		assert.ok(message.includes('pip install'));
+	});
+
+	test('any other failure surfaces the sidecar stderr', () => {
+		const message = describeStartFailure('python', 'Traceback: boom', undefined);
+
+		assert.ok(message.includes('Traceback: boom'));
+	});
+});
+
+suite('sidecar: port handshake', () => {
+	test('reads the port from the announcement line', async () => {
+		const child = fakeChild();
+		const port = readPortLine(child, 'python', () => '');
+
+		child.stdout.write(`${PORT_LINE_PREFIX}54321\n`);
+
+		assert.strictEqual(await port, 54321);
+	});
+
+	test('ignores output printed before the port line', async () => {
+		// Regression guard: puml_encoder.py used to print at import time, so
+		// reading only the first line of stdout picked up debug output and the
+		// handshake failed. Scan, do not assume line 1.
+		const child = fakeChild();
+		const port = readPortLine(child, 'python', () => '');
+
+		child.stdout.write('Bob -> Alice : hello\n');
+		child.stdout.write('some other noise\n');
+		child.stdout.write(`${PORT_LINE_PREFIX}54321\n`);
+
+		assert.strictEqual(await port, 54321);
+	});
+
+	test('tolerates the line arriving split across chunks', async () => {
+		const child = fakeChild();
+		const port = readPortLine(child, 'python', () => '');
+
+		child.stdout.write(`${PORT_LINE_PREFIX}54`);
+		child.stdout.write('3');
+		child.stdout.write('21\n');
+
+		assert.strictEqual(await port, 54321);
+	});
+
+	test('does not accept an incomplete line as a port', async () => {
+		// "5432" with no newline could be the first half of 54321.
+		const child = fakeChild();
+		let settled = false;
+		readPortLine(child, 'python', () => '').then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			}
+		);
+
+		child.stdout.write(`${PORT_LINE_PREFIX}5432`);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		assert.strictEqual(settled, false, 'resolved before the line was complete');
+	});
+
+	test('rejects with an actionable message when the child cannot spawn', async () => {
+		const child = fakeChild();
+		const port = readPortLine(child, 'nonexistent-python', () => '');
+
+		child.emit('error', Object.assign(new Error('spawn failed'), { code: 'ENOENT' }));
+
+		await assert.rejects(port, /nonexistent-python/);
+	});
+
+	test('rejects when the child exits before reporting a port', async () => {
+		const child = fakeChild();
+		const port = readPortLine(
+			child,
+			'python',
+			() => "ModuleNotFoundError: No module named 'plantuml_gui'"
+		);
+
+		child.emit('exit', 1);
+
+		await assert.rejects(port, /pip install/);
+	});
+});

--- a/plantuml-extension/test/sidecar.test.js
+++ b/plantuml-extension/test/sidecar.test.js
@@ -7,6 +7,7 @@ const {
 	describeStartFailure,
 	readPortLine,
 	resolvePythonPath,
+	SidecarStartError,
 	PORT_LINE_PREFIX
 } = require('../src/sidecar');
 
@@ -65,17 +66,23 @@ suite('sidecar: interpreter resolution', () => {
 		assert.strictEqual(await resolvePythonPath(), '/custom/python');
 	});
 
-	test('falls back to a platform-appropriate command', async () => {
+	test('throws instead of guessing when nothing is configured', async () => {
 		delete process.env.PLANTUML_GUI_PYTHON;
 
-		const resolved = await resolvePythonPath();
+		// The backend is a Python package no machine has by default, so an
+		// interpreter found by searching almost certainly cannot import
+		// plantuml_gui. Spawning one would blame the wrong thing.
+		await assert.rejects(() => resolvePythonPath(), SidecarStartError);
+	});
 
-		// With no setting, no env var, and (in the test host) no Python
-		// extension or workspace venv, this is the last resort.
-		assert.ok(
-			resolved === 'python' || resolved === 'python3' || require('fs').existsSync(resolved),
-			`unexpected interpreter: ${resolved}`
-		);
+	test('the unconfigured error names both knobs', async () => {
+		delete process.env.PLANTUML_GUI_PYTHON;
+
+		await assert.rejects(() => resolvePythonPath(), (err) => {
+			assert.ok(err.message.includes('plantumlInteractive.pythonPath'), err.message);
+			assert.ok(err.message.includes('PLANTUML_GUI_PYTHON'), err.message);
+			return true;
+		});
 	});
 });
 

--- a/plantuml-extension/test/sidecar.test.js
+++ b/plantuml-extension/test/sidecar.test.js
@@ -1,3 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+// MIT License
+
+// Copyright (c) 2026 Ericsson
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 const assert = require('assert');
 const { EventEmitter } = require('events');
 const { PassThrough } = require('stream');


### PR DESCRIPTION
  ## Summary
  
  Adds `plantuml-extension/src/sidecar.js`: the Node half of running the Python
  backend as a child process. It resolves a Python interpreter, spawns
  `python -m plantuml_gui.serve`, learns the port the server bound to, waits until
  it is actually serving, and tears it down.
  
  Split out of the original commit whose backend half (`serve.py`) landed
  separately, so the two sides can be reviewed independently.
  
  ## What it does
  
  - `startSidecar()` — spawn, port handshake, health check, returns a `Sidecar`.
  - `Sidecar` — the child process plus the port and token needed to talk to it,
    with `isRunning` and `dispose()`.
  - `resolvePythonPath()` — the interpreter to spawn, from explicit configuration.
  - `buildEnv()` — the environment contract with `serve.py`.
  - `readPortLine()` — reads the port off the child's stdout.
  - `waitForHealthy()` — polls `/health` until the server answers.
  - `describeStartFailure()` — turns spawn/boot failures into actionable messages.
  
  ## Decisions worth a look
  
  **Interpreter resolution refuses to guess.** Only two sources are consulted —
  the `plantumlInteractive.pythonPath` setting and `PLANTUML_GUI_PYTHON` — and if
  neither is set it throws rather than spawning something. The backend is a Python
  package that no machine carries by default, so an interpreter found by searching
  is one that almost certainly cannot import `plantuml_gui`; spawning it would
  turn "the backend is not installed" into an import error blamed on an unrelated
  interpreter. The second commit removes the four speculative candidates the first
  one had, including a bare `python3` fallback.
  
  A later branch in this stack adds back exactly one non-guessed candidate: a
  virtualenv at a fixed path, provisioned by a setup script, which is the one
  interpreter that can be expected to have the package.
  
  **The jar is passed as `PLANTUML_GUI_JAR_OVERRIDE`, not `PLANTUML_JAR`.**
  `shared/render.py` calls `load_dotenv(override=True)` at import time, and that
  import happens via `from .app import app` before `main()` runs — so a repo-root
  `.env` would silently overwrite anything we set. `serve.py` copies the override
  into `PLANTUML_JAR` after that import, which works because `render.py` reads the
  variable per render call rather than capturing it at import.
  
  **The port line is found by scanning stdout for the prefix, not by reading the
  first line.** Anything printed during import would otherwise be mistaken for the
  port — `puml_encoder.py` used to print at import time and broke exactly this.
  
  **A fresh random token per launch.** This is an HTTP server on loopback that any
  local process can reach, and every route rewrites the user's source, so the token
  is the only thing standing between another local process and write access to the
  user's files.
  
  **Retained stderr is capped at 8 KB.** Werkzeug logs every request there for the
  life of the process, so an uncapped buffer would grow without bound.
  
  **Two separate timeouts** — 30 s for startup (booting Python and importing Flask
  is slow on a cold filesystem or with antivirus scanning the interpreter) and 2 s
  per health request.
  
  ## Not wired up yet
  
  Nothing calls `startSidecar()` in this branch — `extension.js` still renders
  read-only through `plantumlRenderer.js`. The webview is connected to the sidecar
  in a later branch in this stack, so there is no user-visible change here.
  
  ## Testing
  
  `test/sidecar.test.js` covers four areas: the environment contract, interpreter
  resolution (including that it throws rather than inventing an interpreter),
  startup failure messages, and the port handshake — with the regression above and
  chunk boundaries falling mid-number. The handshake tests drive a fake child
  process, so no Python is launched.