### PR TITLE
Ext/diagram toolbar

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -37,8 +37,8 @@ app, running as-is.
 │ │ sidecar.js      spawn · handshake  │  ①   │   shims   fetchShim · editorShim ·          │  │
 │ │                 token · /health    │◄────►│           webviewInit                       │  │
 │ │ plantumlJar.js  validate the jar   │      │   app     script.js · title.js ·            │  │
-│ │ webviewPage.js  fetch the page     │      │           hover-highlight ·                 │  │
-│ │                                    │      │           sequence-*.js · activity.js       │  │
+│ │ webviewPage.js  fetch the page     │      │           hover-highlight · activity.js ·   │  │
+│ │                                    │      │           sequence-*.js · diagram-toolbar   │  │
 │ │ ★ the ONLY writer of the document  │      │   css     styles.css · webview.css          │  │
 │ │                                    │      │                                             │  │
 │ │ owns: TextDocument · WorkspaceEdit │      │ shipped in the extension (node_modules):    │  │
@@ -46,8 +46,8 @@ app, running as-is.
 │ │                                    │      │           diff   — no Ace, no Popper        │  │
 │ └────────────────────────────────────┘      └─────────────────────────────────────────────┘  │
 │         │              │                                        │                            │
-│      ②  │ spawn +   ③  │ GET /webview                        ④  │ the app's own HTTP,        │
-│         │ stdio        │ once per panel                         │ every interaction          │
+│      ②  │ spawn +   ③  │ GET /webview once per panel,           │ the app's own HTTP,        │
+│         │ stdio        │ POST /renderPNG on save                │ every interaction          │
 └─────────┼──────────────┼────────────────────────────────────────┼────────────────────────────┘
           ▼              ▼                                        ▼
 ┌─ SIDECAR · Python · Flask ───────────────────────────────────────────────────────────────────┐
@@ -56,7 +56,7 @@ app, running as-is.
 │ X-PlantUML-Token required on every request but GET /static/*                                 │
 │                                                                                              │
 │ serve.py         ephemeral port · /health · /webview · token auth · CORS · jar override      │
-│ templates/       webview.html · app_scripts · activity_menus · sequence_menus                │
+│ templates/       webview.html · app_scripts · diagram_toolbar · activity/sequence_menus      │
 │ static/          every script and stylesheet the page loads, incl. vscode/ shims             │
 │ 79 POST routes   56 rewrite the source   /editText · /addNote · /deleteActivity …            │
 │                  23 query or render      /getText · /getActivityPositions · /render …        │
@@ -78,15 +78,16 @@ The five edges, each specified in full under [Interfaces](#interfaces):
 | --- | --- | --- | --- |
 | ① | host ↔ webview | `postMessage` | continuous |
 | ② | host → sidecar | `spawn` + stdio | once per window |
-| ③ | host → sidecar | one HTTP `GET /webview` | once per panel |
+| ③ | host → sidecar | HTTP: `GET /webview`, `POST /renderPNG` | once per panel; once per PNG saved |
 | ④ | webview → sidecar | the frontend's own HTTP | every interaction |
 | ⑤ | sidecar → java | `subprocess` | once per render |
 
 Two independent channels, and the split is the whole design. The webview talks **HTTP to
 Python** for everything about the diagram, and **`postMessage` to Node** for everything about
-the document. Node never proxies ④ — its only HTTP request is ③, made once, before the page
-exists. Python never learns that a file is involved: every route takes the full source in the
-request body and returns the full source back.
+the document. Node never proxies ④ — its own HTTP is ③: the page fetch, made once before the
+page exists, and the PNG render, which is Node's only because a webview cannot receive a file.
+Python never learns that a file is involved: every route takes the full source in the request
+body and returns the full source back.
 
 Note where the frontend lives. Only the browser libraries come from the extension; the page,
 the shims, the CSS and the app's own scripts are all served by the sidecar out of
@@ -113,10 +114,12 @@ Python side, `src/plantuml_gui/`:
 | `serve.py` | The sidecar entry point. Same Flask `app`, different startup: ephemeral port, `/health`, `/webview`, token auth, CORS, jar override. |
 | `templates/webview.html` | The page the panel loads. Standalone, not a child of `index.html`. |
 | `templates/partials/app_scripts.html` | The frontend's script list, shared by `index.html` and `webview.html`. |
+| `templates/partials/diagram_toolbar.html` | The toolbar markup, shared by the same two pages; takes the attributes they differ on. |
+| `static/diagram-toolbar.js` | Panzoom and the zoom buttons, for both pages. Loads at the end of `<body>`, not with `app_scripts`. |
 | `static/vscode/fetchShim.js` | Rewrites the app's relative `fetch()` URLs and attaches the token. |
 | `static/vscode/editorShim.js` | An Ace-shaped object backed by the VS Code document. |
 | `static/vscode/webviewInit.js` | Boots the reused app code inside the webview. |
-| `static/vscode/webview.css` | Hides the DOM elements that exist only to satisfy the app's code. |
+| `static/vscode/webview.css` | Lays out the toolbar and the diagram, repaints them in the editor's theme, and hides the DOM elements that exist only to satisfy the app's code. |
 
 Nothing under `static/vscode/` is loaded by the web app at `/`. It lives in this package
 rather than in the extension because it is `<script src>` on a page Flask renders — serving
@@ -162,13 +165,22 @@ naming the setting to fix.
 
 ### 2. Host → sidecar: HTTP
 
-Two requests in the extension's whole lifetime — Node is not a proxy for the frontend. Both
-carry `X-PlantUML-Token`.
+Node is not a proxy for the frontend: it makes three requests, two of them once each per
+panel, and every interaction with the diagram goes straight from the webview to the sidecar
+instead. All three carry `X-PlantUML-Token`.
 
 | Request | When | Response | On failure |
 | --- | --- | --- | --- |
 | `GET /health` | Every 100 ms after the port line until it answers or 30 s passes; 2 s per attempt. | `{"status": "ok"}` — the body is never read, only the fact that something answered. | Not-ready-yet; the deadline is what gives up. |
 | `GET /webview?…` | Once per panel, 5 s timeout. | `text/html`, assigned verbatim to `panel.webview.html`. | `400` + `{"error": …}` on a bad parameter, `WebviewPageError` otherwise. |
+| `POST /renderPNG` | On `savePng`, 60 s timeout — the render shells out to java. | `image/png` bytes, written to the file the save dialog returns. | Notification; nothing is written. |
+
+The third one is the exception that proves the rule. It is the frontend's own route, called
+with the frontend's own envelope, and the webview would be the natural caller — but a webview
+has no filesystem and blocks downloads, so the bytes have to arrive in this process no matter
+who fetches them. Asking here costs one request; asking there would cost the same request
+plus a base64 copy of a 300-dpi image across the `postMessage` boundary. See
+[Saving a PNG](#saving-a-png).
 
 The `/webview` query string is the whole of what the extension tells Flask about the panel:
 
@@ -198,6 +210,7 @@ instances do not. Every message carries a `type` discriminator.
 | host → webview | `cursorMoved` | `{ row, column }` | On `onDidChangeTextEditorSelection`, undebounced, zero-based. |
 | webview → host | `applyPuml` | `{ text }` | A diagram operation produced new source. |
 | webview → host | `setHighlight` | `{ rows }`, zero-based line numbers | The shim's marker table changed. |
+| webview → host | `savePng` | `{}` | The toolbar's PNG button was clicked. Carries no source: the host renders from the document. |
 | webview → host | `ready` | `{}` | The page finished booting. |
 
 Four properties of the channel shape the code on both sides. There is **no
@@ -449,9 +462,11 @@ Three libraries `index.html` loads are deliberately absent:
   through Bootstrap's own JS. The page uses Bootstrap for modals, which do not need it, and
   the context menus are `.dropdown-menu` markup positioned and toggled by the app's own code
   rather than by `data-toggle="dropdown"`. The one `data-toggle="dropdown"` in the codebase
-  is on `index.html`'s toolbar, which this page does not have.
-- **tippy.js** — only ever bound to `[data-tippy-content]`, which is exclusively
-  `index.html`'s toolbar buttons.
+  is on `index.html`'s global bar, which this page does not have.
+- **tippy.js** — only ever bound to `[data-tippy-content]`. This page shares its toolbar markup
+  with `index.html`, so the shared macro takes the attribute name as an argument: the buttons
+  carry plain `title` tooltips here, and a test asserts the page requests no tooltip it cannot
+  show.
 
 ### DOM the app assumes
 
@@ -459,6 +474,35 @@ Three libraries `index.html` loads are deliberately absent:
 `webview.css`. They exist because the app's code dereferences those ids without null checks;
 one missing id throws during setup and kills every interaction while the diagram still
 renders.
+
+The toolbar's four ids — `#zoom-in`, `#zoom-out`, `#zoom-fit`, `#png` — look like more of the
+same but are not. The app's `buttonEventListeners()` binds `#png` too, and this page never
+calls it (see [`webviewInit.js`](#webviewinitjs)); these are the page's own ids, bound by
+`webviewInit.js` to its own handlers. They are dereferenced without a null check for the same
+reason, so the same failure mode applies.
+
+### The toolbar
+
+Shared with `index.html`, not copied from it, in both halves: the markup is the
+`diagram_toolbar` macro in `partials/diagram_toolbar.html`, and the three zoom buttons are
+wired by `static/diagram-toolbar.js`, which both pages load. That code used to be inline in
+`index.html`; it moved into a file precisely because this page cannot run an inline script.
+It is not in `app_scripts.html` with the rest of the frontend, because unlike those it reads
+the DOM as it runs and so has to load at the end of `<body>` rather than from `<head>`.
+
+The macro takes the two arguments the pages differ on. `tooltip_attr` is an attribute *name*:
+`data-tippy-content` for `index.html`, `title` here, for the reason under
+[Browser libraries](#browser-libraries). `png_tooltip` differs because `#png` is the one
+button whose behaviour is not shared at all — see [Saving a PNG](#saving-a-png) — so each page
+wires it separately, `index.html` through `buttonEventListeners()` and this page through
+`webviewInit.js`.
+
+What is genuinely webview-only is the CSS. `webview.css` changes two things: `body` becomes a
+flex column with the diagram as the growing item — replacing `#colb-container`'s
+`position: absolute; inset: 0`, which assumed the diagram was the whole panel — and the
+palette tokens are redefined *on the toolbar* in terms of `--vscode-*`. Scoped there rather
+than on `:root` because `tokens.css` is a fixed light theme that the context menus read too;
+overriding globally would repaint them.
 
 ## The shims
 
@@ -507,22 +551,27 @@ It deliberately does not call the web app's own bootstrap:
 
 - `initeditor()` builds an Ace instance and, finding no `?hash` in the URL, calls
   `setDemo()`, which would overwrite the user's file with the demo diagram.
-- `addUtilEventListeners()` calls `buttonEventListeners()`, which binds the web toolbar
-  (New/Undo/Save/PNG). Those buttons do not exist here, and `addEventListener` on `null`
-  throws.
+- `addUtilEventListeners()` calls `buttonEventListeners()`, which binds the web app's global
+  bar (New/Undo/Save/PNG). Most of those buttons do not exist here, and `addEventListener` on
+  `null` throws. `#png` is the exception and still must not go through it: that handler
+  downloads through an `<a download>`, which a webview blocks. See [Saving a PNG](#saving-a-png).
 
 So the listeners `initeditor()` would have registered are re-registered explicitly —
 `session.on('change')` and `selection.on('changeCursor')` — without which the diagram would
 render once at boot and never again. It then calls `titleEventListeners()`, binds Ctrl+Enter
 for modal submit (Ctrl+Z is deliberately *not* rebound, since every edit is a `WorkspaceEdit`
-and already on VS Code's undo stack), sets up panzoom on `#colb`, and posts `ready`.
+and already on VS Code's undo stack), binds `#png`, and posts `ready`.
+
+`#png` is the one line here that adds behaviour rather than restoring it, and the only part of
+the toolbar this file owns: panning and the zoom buttons are already set up by
+`static/diagram-toolbar.js`, loaded just before it. All it does is post `savePng`.
 
 The context menus need no attention here: they are wired by `checkDiagramType()` during
 `renderPlantUml()`.
 
 ## Message protocol
 
-The five message types, their payloads and the guarantees the channel does and does not give
+The six message types, their payloads and the guarantees the channel does and does not give
 are specified under *Host ↔ webview* in [Interfaces](#interfaces). What follows is the part
 that the message list does not show: why the two directions do not chase each other forever.
 
@@ -565,6 +614,37 @@ webview   applyDocumentText(text) → identical → returns false. Loop ends.
 
 Typing directly in the VS Code editor enters the same flow at
 `onDidChangeTextDocument`, where `applyDocumentText` returns `true` and a re-render follows.
+
+## Saving a PNG
+
+The one feature that runs backwards through the architecture. Everywhere else the webview
+talks to the sidecar and the host only owns the document; here the host does both.
+
+```
+webview   #png clicked → post {savePng}          no payload
+host      POST /renderPNG {plantuml: document.getText()}
+sidecar   routes.py renderpng() → render.py → java -pipe -tpng -Sdpi=300
+sidecar   send_file(image/png) → response.arrayBuffer()
+host      showSaveDialog → workspace.fs.writeFile
+```
+
+Three things about it are deliberate:
+
+- **The message carries no source.** The document is the authority — every diagram edit
+  reaches it through `applyPuml` before a render can be asked for — and the webview's copy is
+  a shim's cache of the same text. Reading it here removes the question of which is newer.
+  It also means the PNG ignores the panel's pan and zoom, and comes out identical to the one
+  the web app's button produces.
+- **An empty body is a failure.** `_create_png_from_uml` runs java with `check=False` and
+  returns its stdout whatever happened, so a jar that could not run arrives as `200` with
+  nothing in it. Writing that leaves a zero-byte `.png` that looks like a save that worked, so
+  the host checks the length before opening the dialog.
+- **A cancelled dialog is not an error.** `showSaveDialog` resolves to `undefined`, and the
+  handler returns without a notification.
+
+The web app's own `#png` handler in `script.js` is never reached: it is registered by
+`buttonEventListeners()`, which `webviewInit.js` does not call. Its approach — a temporary
+`<a download>` — cannot work in a webview at all.
 
 ## Highlighting
 
@@ -626,8 +706,9 @@ Each site carries a comment naming the other.
 | `PLANTUML_GUI_PORT=` | `src/sidecar.js` (`PORT_LINE_PREFIX`) | `serve.py` (`PORT_LINE_PREFIX`) |
 | `X-PlantUML-Token` | `src/sidecar.js` (`TOKEN_HEADER`) | `serve.py` (`TOKEN_HEADER`) |
 | `/webview` | `src/webviewPage.js` (`WEBVIEW_PATH`) | `serve.py` (`WEBVIEW_ROUTE`) |
+| `/renderPNG` | `extension.js` (`savePng`) | `shared/routes.py` (`renderpng`) |
 | `PLANTUML_GUI_TOKEN`, `PLANTUML_GUI_JAR_OVERRIDE` | `src/sidecar.js` (`buildEnv`) | `serve.py` (`TOKEN_ENV`, `JAR_ENV`) |
-| The five message types | `extension.js` | `static/vscode/` shims |
+| The six message types | `extension.js` | `static/vscode/` shims |
 
 One more invariant lives entirely in the page: the script load order in `webview.html` —
 vendor, then shims, then app, then boot. Every step of it is justified in that file.

--- a/plantuml-extension/extension.js
+++ b/plantuml-extension/extension.js
@@ -31,12 +31,16 @@
 // webview calls directly; this file owns the document and is its only writer.
 // The webview's page is rendered by that same backend and fetched by
 // src/webviewPage.js.
+const path = require('path');
 const vscode = require('vscode');
-const { startSidecar, SidecarStartError } = require('./src/sidecar');
+const { startSidecar, SidecarStartError, TOKEN_HEADER } = require('./src/sidecar');
 const { resolvePlantUmlJarPath, PlantUmlConfigError } = require('./src/plantumlJar');
 const { fetchWebviewPage, vendorRoot, WebviewPageError } = require('./src/webviewPage');
 
 const LIVE_UPDATE_DEBOUNCE_MS = 300;
+
+/** Generous because rendering shells out to java, once per request. */
+const RENDER_PNG_TIMEOUT_MS = 60000;
 
 /**
  * Line highlight for the diagram -> editor direction: hovering an element in
@@ -231,6 +235,8 @@ async function openDiagramPanel(context) {
 			}
 		} else if (message.type === 'setHighlight') {
 			applyHighlight(document, message.rows);
+		} else if (message.type === 'savePng') {
+			await savePng(document, active);
 		} else if (message.type === 'ready') {
 			outputChannel?.appendLine('[webview] frontend loaded');
 		}
@@ -284,6 +290,91 @@ async function applyPuml(document, text) {
 	if (!(await vscode.workspace.applyEdit(edit))) {
 		vscode.window.showErrorMessage('Could not write the diagram change into the document.');
 	}
+}
+
+/**
+ * Render the document as a PNG and write it wherever the user chooses.
+ *
+ * The webview posts a bare `savePng`; the source comes from the document,
+ * which this process owns and which every diagram edit is written into before
+ * a render can be asked for.
+ *
+ * @param {vscode.TextDocument} document
+ * @param {import('./src/sidecar').Sidecar} sidecar a running sidecar
+ */
+async function savePng(document, sidecar) {
+	let response;
+
+	try {
+		response = await fetch(`${sidecar.baseUrl}renderPNG`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				[TOKEN_HEADER]: sidecar.token
+			},
+			body: JSON.stringify({ plantuml: document.getText() }),
+			signal: AbortSignal.timeout(RENDER_PNG_TIMEOUT_MS)
+		});
+	} catch (err) {
+		vscode.window.showErrorMessage(`Could not render the diagram as a PNG: ${err.message}`);
+		return;
+	}
+
+	if (!response.ok) {
+		vscode.window.showErrorMessage(
+			`The PlantUML backend returned ${response.status} for the PNG render.`
+		);
+		return;
+	}
+
+	// An empty body is a *successful* response here: the backend renders with
+	// check=False and returns java's stdout whatever happened, so a jar that
+	// failed to run arrives as 200 with nothing in it. Hence the length check
+	// below, which keeps a zero-byte .png off disk.
+	const png = new Uint8Array(await response.arrayBuffer());
+
+	if (png.byteLength === 0) {
+		vscode.window.showErrorMessage(
+			'The PlantUML backend produced an empty PNG. Check the PlantUML Interactive output for the renderer error.'
+		);
+		return;
+	}
+
+	const target = await vscode.window.showSaveDialog({
+		defaultUri: defaultPngUri(document),
+		filters: { 'PNG image': ['png'] }
+	});
+
+	// Undefined when the dialog was cancelled, which is not a failure.
+	if (!target) {
+		return;
+	}
+
+	try {
+		await vscode.workspace.fs.writeFile(target, png);
+	} catch (err) {
+		vscode.window.showErrorMessage(`Could not write ${target.fsPath}: ${err.message}`);
+	}
+}
+
+/**
+ * Where the save dialog should open: beside the document, under its own name.
+ *
+ * An unsaved document has no directory to sit beside -- its uri is
+ * `untitled:Untitled-1` -- so it falls back to the workspace root, and then to
+ * VS Code's own choice.
+ *
+ * @param {vscode.TextDocument} document
+ * @returns {vscode.Uri | undefined}
+ */
+function defaultPngUri(document) {
+	if (document.uri.scheme === 'file') {
+		const { dir, name } = path.parse(document.uri.fsPath);
+		return vscode.Uri.file(path.join(dir, `${name}.png`));
+	}
+
+	const folder = vscode.workspace.workspaceFolders?.[0];
+	return folder && vscode.Uri.joinPath(folder.uri, 'diagram.png');
 }
 
 /**

--- a/plantuml-extension/test/extension.test.js
+++ b/plantuml-extension/test/extension.test.js
@@ -86,6 +86,51 @@ suite('extension: activation', () => {
 	});
 });
 
+suite('extension: message protocol', () => {
+	test('handles every message type the webview posts', () => {
+		// The two ends live in different packages and are kept in step by
+		// hand; this is the check that they still are. See "Cross-runtime
+		// contracts" in docs/extension.md. It matters because the channel has
+		// no acks and both handlers are if/else-if chains, so a type the page
+		// posts and the host misses is dropped in silence -- the button simply
+		// does nothing.
+		const posted = new Set();
+
+		for (const source of readWebviewShims()) {
+			for (const [, type] of source.matchAll(/post(?:Message)?\(\{\s*type:\s*'([^']+)'/g)) {
+				posted.add(type);
+			}
+		}
+
+		const [, extensionSource] = readSources().find(([relative]) => relative === 'extension.js');
+		const handled = new Set(
+			[...extensionSource.matchAll(/message\.type === '([^']+)'/g)].map(([, type]) => type)
+		);
+
+		assert.ok(posted.has('savePng'), 'the shims no longer post savePng');
+		assert.deepStrictEqual(
+			[...posted].filter((type) => !handled.has(type)),
+			[],
+			'posted by the webview, not handled by the host'
+		);
+	});
+});
+
+/**
+ * @returns {string[]} the contents of the webview-side shims, which live in
+ *   the Python package rather than here; see the header of fetchShim.js.
+ */
+function readWebviewShims() {
+	const fs = require('fs');
+	const path = require('path');
+	const shims = path.join(__dirname, '..', '..', 'src', 'plantuml_gui', 'static', 'vscode');
+
+	return fs
+		.readdirSync(shims)
+		.filter((name) => name.endsWith('.js'))
+		.map((name) => fs.readFileSync(path.join(shims, name), 'utf-8'));
+}
+
 /**
  * @returns {[string, string][]} every source file the extension ships, as
  *   [path relative to the extension root, contents].

--- a/src/plantuml_gui/static/diagram-toolbar.js
+++ b/src/plantuml_gui/static/diagram-toolbar.js
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+
+// MIT License
+
+// Copyright (c) 2026 Ericsson
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Pan and zoom for the diagram, and the three zoom buttons that drive it.
+//
+// Loaded by both pages that render partials/diagram_toolbar.html: index.html
+// and the extension's webview.html, which needs the behaviour in a file
+// because its CSP allows no inline script.
+//
+// Reads the DOM as it runs, so it loads at the end of <body>.
+//
+// The toolbar's fourth button, #png, is wired by each page separately:
+// script.js's buttonEventListeners() for index.html, static/vscode/
+// webviewInit.js for the webview.
+
+(function () {
+	const MAX_ZOOM = 3;
+	const MIN_ZOOM = 0.25;
+	const ZOOM_STEP = 1.1;
+
+	const diagram = document.getElementById('colb');
+
+	if (!window.panzoom || !diagram) {
+		return;
+	}
+
+	const instance = panzoom(diagram, {
+		maxZoom: MAX_ZOOM,
+		minZoom: MIN_ZOOM,
+		bounds: true
+	});
+
+	// Read by the e2e tests, which assert on the scale after a button click.
+	// See tests/e2e/test_ribbon.py.
+	window.panzoomInstance = instance;
+
+	// Double-click is an editing gesture on both pages (it opens the text for
+	// the element under the cursor), so stop panzoom treating it as
+	// zoom-to-point.
+	diagram.addEventListener('dblclick', (event) => event.stopImmediatePropagation());
+
+	// Zoom about the current pan origin, so repeated clicks stay on the same
+	// part of the diagram. zoomAbs applies the scale verbatim, so the bounds
+	// panzoom enforces on wheel input are reapplied here.
+	function zoomBy(factor) {
+		const { x, y, scale } = instance.getTransform();
+		const next = Math.min(Math.max(scale * factor, MIN_ZOOM), MAX_ZOOM);
+		instance.zoomAbs(x, y, next);
+	}
+
+	document.getElementById('zoom-in').addEventListener('click', () => zoomBy(ZOOM_STEP));
+	document.getElementById('zoom-out').addEventListener('click', () => zoomBy(1 / ZOOM_STEP));
+	document.getElementById('zoom-fit').addEventListener('click', () => {
+		instance.moveTo(0, 0);
+		instance.zoomAbs(0, 0, 1);
+	});
+})();

--- a/src/plantuml_gui/static/vscode/webview.css
+++ b/src/plantuml_gui/static/vscode/webview.css
@@ -45,9 +45,22 @@ body {
     font-family: var(--vscode-font-family);
 }
 
+/* Toolbar above, diagram filling the rest. Those two are the only children
+   that take part: #popup is absolute, the three hidden ids below are
+   display:none, and the menu partials contribute .modals and .dropdown-menus,
+   which are display:none until shown. */
+body {
+    display: flex;
+    flex-direction: column;
+}
+
 #colb-container {
-    position: absolute;
-    inset: 0;
+    flex: 1;
+    /* Lets the item shrink below its content, so a diagram taller than the
+       panel scrolls under the toolbar instead of pushing it off the top. */
+    min-height: 0;
+    /* The containing block #loading-overlay's inset:0 resolves against. */
+    position: relative;
     /* hidden, not auto: panzoom translates #colb, so a scrollbar here would
        fight the drag gesture. */
     overflow: hidden;
@@ -60,6 +73,27 @@ body {
 
 #colb svg {
     max-width: none;
+}
+
+/* toolbars.css keeps the layout; only the palette changes. tokens.css defines
+   these as a fixed light theme (--bg-toolbar is #f0f0f2), so in the editor's
+   theme they become the --vscode-* vars the webview host sets, with fallbacks
+   for the themes that leave one unset.
+
+   Scoped to the toolbar: custom properties inherit, so this reaches its
+   buttons, while the context menus keep the tokens.css values they are drawn
+   with. */
+.diagram-toolbar {
+    --bg-toolbar: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+    --border-color: var(--vscode-panel-border, transparent);
+    --text-primary: var(--vscode-foreground);
+    --btn-hover-bg: var(--vscode-toolbar-hoverBackground, transparent);
+    --btn-active-bg: var(--vscode-toolbar-activeBackground, transparent);
+    --border-hover: transparent;
+    --accent-text: var(--vscode-button-foreground);
+    --accent-bg: var(--vscode-button-background);
+    --accent-border: var(--vscode-button-border, transparent);
+    --accent-hover-bg: var(--vscode-button-hoverBackground, var(--vscode-button-background));
 }
 
 /* The VS Code text editor is the source editor. These three exist only because

--- a/src/plantuml_gui/static/vscode/webviewInit.js
+++ b/src/plantuml_gui/static/vscode/webviewInit.js
@@ -37,8 +37,11 @@
 //   - initeditor() builds an Ace instance and, finding no ?hash in the URL,
 //     calls setDemo() -- which would overwrite the user's file with the demo.
 //   - addUtilEventListeners() calls buttonEventListeners(), which binds the web
-//     app's toolbar (New/Undo/Save/PNG...). Those buttons do not exist here, and
-//     getElementById(...).addEventListener on null throws.
+//     app's global bar (New/Undo/Save/PNG...). Most of those buttons do not
+//     exist here, and getElementById(...).addEventListener on null throws.
+//     #png does exist, and this file binds it below to a handler that suits a
+//     webview: the web app's downloads through an <a download>, which a
+//     webview blocks.
 // The context menus themselves are wired by checkDiagramType() during
 // renderPlantUml(), which is why every diagram interaction works without us
 // touching it.
@@ -117,15 +120,12 @@
 		}
 	});
 
-	// Pan and zoom the diagram, as the web app's index.html does.
-	const diagram = document.getElementById('colb');
-	if (window.panzoom && diagram) {
-		const instance = panzoom(diagram, { maxZoom: 3, minZoom: 0.25, bounds: true });
-		// Double-click is an editing gesture here (edit text), so stop panzoom
-		// treating it as zoom-to-point.
-		diagram.addEventListener('dblclick', (event) => event.stopImmediatePropagation());
-		window.panzoomInstance = instance;
-	}
+	// The toolbar's PNG button. Panning and the three zoom buttons come from
+	// static/diagram-toolbar.js, loaded just before this file.
+	//
+	// The message carries no payload: the host renders the PNG from the
+	// document it owns and writes it, being the runtime with a filesystem.
+	document.getElementById('png').addEventListener('click', () => post({ type: 'savePng' }));
 
 	post({ type: 'ready' });
 })();

--- a/src/plantuml_gui/templates/index.html
+++ b/src/plantuml_gui/templates/index.html
@@ -26,6 +26,7 @@ SOFTWARE.
 
 
 {% from "partials/app_scripts.html" import app_scripts %}
+{% from "partials/diagram_toolbar.html" import diagram_toolbar %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -131,22 +132,7 @@ SOFTWARE.
 
       <!-- Right Pane: Diagram -->
       <div class="right-pane">
-        <div class="diagram-toolbar">
-          <button type="button" id="zoom-out" class="toolbar-btn" data-tippy-content="Zoom out">
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="7" cy="7" r="5"/><path d="M11 11l3.5 3.5" stroke-linecap="round"/><path d="M5 7h4"/></svg>
-          </button>
-          <button type="button" id="zoom-in" class="toolbar-btn" data-tippy-content="Zoom in">
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="7" cy="7" r="5"/><path d="M11 11l3.5 3.5" stroke-linecap="round"/><path d="M5 7h4M7 5v4"/></svg>
-          </button>
-          <button type="button" id="zoom-fit" class="toolbar-btn" data-tippy-content="Reset zoom">
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M2 5V2h3M11 2h3v3M14 11v3h-3M5 14H2v-3"/></svg>
-          </button>
-          <span class="toolbar-spacer"></span>
-          <button type="button" id="png" class="toolbar-btn toolbar-btn--accent" data-tippy-content="Download diagram as PNG">
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M8 2v9M5 8l3 3 3-3"/><path d="M3 12v2h10v-2"/></svg>
-            PNG
-          </button>
-        </div>
+        {{ diagram_toolbar('data-tippy-content', 'Download diagram as PNG') }}
         <div id="colb-container">
           <div id="colb">
             <div id="init-text">
@@ -171,33 +157,8 @@ SOFTWARE.
       await initeditor();
       initialize();
     })();
-    var element = document.getElementById('colb');
-
-    const panzoomInstance = panzoom(element, {
-      maxZoom: 3,
-      minZoom: 0.25,
-      bounds: true,
-    });
-
-    element.addEventListener('dblclick', (event) => {
-      event.stopImmediatePropagation();
-    });
-
-    // Zoom controls
-    document.getElementById('zoom-in').addEventListener('click', () => {
-      const t = panzoomInstance.getTransform();
-      const newScale = Math.min(t.scale * 1.1, 3);
-      panzoomInstance.zoomAbs(t.x, t.y, newScale);
-    });
-    document.getElementById('zoom-out').addEventListener('click', () => {
-      const t = panzoomInstance.getTransform();
-      const newScale = Math.max(t.scale / 1.1, 0.25);
-      panzoomInstance.zoomAbs(t.x, t.y, newScale);
-    });
-    document.getElementById('zoom-fit').addEventListener('click', () => {
-      panzoomInstance.moveTo(0, 0);
-      panzoomInstance.zoomAbs(0, 0, 1);
-    });
+    // Panning and the three zoom buttons live in static/diagram-toolbar.js,
+    // loaded at the foot of this page and shared with the extension's webview.
 
     // Resizable divider
     (function() {
@@ -298,6 +259,10 @@ SOFTWARE.
       duration: [150, 100],
     });
 </script>
+
+<!-- Shared with the extension's webview.html. Loads here, at the foot of the
+     page, because it reads #colb and the toolbar as it runs. -->
+<script src="static/diagram-toolbar.js?v={{ script_hash }}"></script>
 
 </body>
 </html>

--- a/src/plantuml_gui/templates/partials/diagram_toolbar.html
+++ b/src/plantuml_gui/templates/partials/diagram_toolbar.html
@@ -1,0 +1,74 @@
+<!--
+SPDX-License-Identifier: MIT
+
+MIT License
+
+Copyright (c) 2026 Ericsson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The bar above the diagram, for the two pages that have one: index.html and the
+extension's webview.html. Laid out by static/css/toolbars.css; the three zoom
+buttons are wired by static/diagram-toolbar.js, which both pages also load.
+
+Two things differ between the pages, and both are arguments.
+
+`tooltip_attr` is the name of an attribute rather than a value. index.html
+passes `data-tippy-content`, which its tippy.js call at the foot of the page
+binds. The webview passes `title`, the tooltip a browser shows on its own,
+since the extension vendors no tippy.
+
+`png_tooltip` follows what #png does on each page: index.html downloads the
+image, the webview asks the extension host to write it. Each page wires that
+button itself; only the three zoom buttons are shared.
+
+(Jinja reads its tags inside HTML comments too, so do not write one here.)
+-->
+
+{% macro diagram_toolbar(tooltip_attr, png_tooltip) -%}
+<div class="diagram-toolbar">
+    <button type="button" id="zoom-out" class="toolbar-btn" {{ tooltip_attr }}="Zoom out">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+            <circle cx="7" cy="7" r="5" />
+            <path d="M11 11l3.5 3.5" stroke-linecap="round" />
+            <path d="M5 7h4" />
+        </svg>
+    </button>
+    <button type="button" id="zoom-in" class="toolbar-btn" {{ tooltip_attr }}="Zoom in">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+            <circle cx="7" cy="7" r="5" />
+            <path d="M11 11l3.5 3.5" stroke-linecap="round" />
+            <path d="M5 7h4M7 5v4" />
+        </svg>
+    </button>
+    <button type="button" id="zoom-fit" class="toolbar-btn" {{ tooltip_attr }}="Reset zoom">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+            <path d="M2 5V2h3M11 2h3v3M14 11v3h-3M5 14H2v-3" />
+        </svg>
+    </button>
+    <span class="toolbar-spacer"></span>
+    <button type="button" id="png" class="toolbar-btn toolbar-btn--accent" {{ tooltip_attr }}="{{ png_tooltip }}">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+            <path d="M8 2v9M5 8l3 3 3-3" />
+            <path d="M3 12v2h10v-2" />
+        </svg>
+        PNG
+    </button>
+</div>
+{%- endmacro %}

--- a/src/plantuml_gui/templates/webview.html
+++ b/src/plantuml_gui/templates/webview.html
@@ -40,6 +40,7 @@ relative path would resolve to nothing.
 -->
 
 {% from "partials/app_scripts.html" import app_scripts %}
+{% from "partials/diagram_toolbar.html" import diagram_toolbar %}
 <!DOCTYPE html>
 <html lang="en">
 
@@ -92,6 +93,8 @@ relative path would resolve to nothing.
     <span id="version"></span>
     <div id="version-panel"></div>
 
+    {{ diagram_toolbar('title', 'Save diagram as PNG') }}
+
     <div id="colb-container">
         <div id="colb"></div>
         <div id="loading-overlay"></div>
@@ -107,7 +110,9 @@ relative path would resolve to nothing.
                   script.js, which dereferences `ace` at load time (line 46)
                   and would throw mid-parse if the global did not exist yet
       3. app      the frontend, in dependency order
-      4. boot     last, because it assigns script.js's `let editor`
+      4. toolbar  after the markup above and after panzoom, both of which it
+                  reads as it runs
+      5. boot     last, because it assigns script.js's `let editor`
     -->
     {% for src in vendor_scripts %}
     <script src="{{ src }}"></script>
@@ -115,6 +120,7 @@ relative path would resolve to nothing.
     <script src="{{ base }}static/vscode/fetchShim.js?v={{ script_hash }}"></script>
     <script src="{{ base }}static/vscode/editorShim.js?v={{ script_hash }}"></script>
     {{ app_scripts(base, script_hash) }}
+    <script src="{{ base }}static/diagram-toolbar.js?v={{ script_hash }}"></script>
     <script src="{{ base }}static/vscode/webviewInit.js?v={{ script_hash }}"></script>
 </body>
 

--- a/tests/shared/test_serve.py
+++ b/tests/shared/test_serve.py
@@ -235,6 +235,36 @@ def test_webview_page_supplies_the_ids_the_frontend_dereferences(webview_app):
         assert page(f"#{element_id}"), f"#{element_id} is missing from the page"
 
 
+def test_webview_page_gets_the_same_toolbar_as_index(webview_app):
+    """Both pages render partials/diagram_toolbar.html, and diagram-toolbar.js
+    dereferences these ids without a null check on both -- so a button that
+    reaches one page and not the other throws there and takes panzoom with it."""
+    page = webview_page(webview_app)
+    index = PyQuery(
+        webview_app.jinja_env.get_template("index.html").render(
+            script_hash="x", version="0"
+        )
+    )
+
+    buttons = [element.attrib["id"] for element in index(".diagram-toolbar button")]
+    assert buttons, "index.html has no toolbar to share"
+
+    for element_id in buttons:
+        assert page(
+            f".diagram-toolbar button#{element_id}"
+        ), f"#{element_id} is missing"
+
+
+def test_webview_page_does_not_ask_for_tooltips_it_cannot_show(webview_app):
+    """tippy.js binds [data-tippy-content] and the extension vendors no tippy,
+    so the shared macro takes the attribute name: index.html gets tippy's, this
+    page gets title. Passing the wrong one leaves buttons silent on hover."""
+    page = webview_page(webview_app)
+
+    assert not page("[data-tippy-content]")
+    assert page(".diagram-toolbar button[title]"), "the buttons have no tooltip at all"
+
+
 def test_webview_page_includes_the_menus_from_the_same_partials_as_index(webview_app):
     """The context menus are ~95 of the ids the frontend needs. Sharing the
     partials with index.html is what keeps them from drifting apart."""


### PR DESCRIPTION
**Shared, not copied** — both halves of the toolbar now have one home:
  
  - `templates/partials/diagram_toolbar.html` — the markup, as a macro, included by
    `index.html` and `webview.html`. It takes the two arguments the pages differ
    on: `tooltip_attr` (an attribute *name* — `data-tippy-content` for the web app,
    `title` in the webview, which vendors no tippy) and `png_tooltip`.
  - `static/diagram-toolbar.js` — panzoom and the three zoom buttons, lifted out of
    `index.html`'s inline `<script>` and out of `webviewInit.js`, which had its own
    copy of the panzoom setup. Loads at the foot of `<body>` on both pages because
    it reads the DOM as it runs, so it is not in `app_scripts.html`. It had to
    become a file at all because the webview's CSP allows no inline script.
  - `static/vscode/webview.css` — the only genuinely webview-only part. `body`
    becomes a flex column with the diagram as the growing item (replacing
    `#colb-container`'s `position: absolute; inset: 0`, which assumed the diagram
    was the whole panel), and the palette tokens are redefined *on the toolbar* in
    terms of `--vscode-*`. Scoped there, not on `:root`, because `tokens.css` is a
    fixed light theme that the context menus also read.
  
  **PNG saving** runs backwards through the architecture, and that is the one
  interesting thing here. Everywhere else the webview talks to the sidecar and the
  host only owns the document; for this the host does both, because a webview has
  no filesystem and blocks `<a download>`. So the button posts a bare `savePng`,
  and `extension.js` renders via `POST /renderPNG` and writes the bytes through
  `showSaveDialog` + `workspace.fs.writeFile`. Three deliberate details:
  
  - The message carries no source — the document is the authority, so there is no
    question of which copy is newer.
  - An empty body is a *failure*: `_create_png_from_uml` runs java with
    `check=False`, so a jar that could not run arrives as `200` with nothing in it.
    The length check keeps a zero-byte `.png` off disk.
  - A cancelled dialog is not an error.
  
  `docs/extension.md` is updated throughout: the diagram, the interface tables
  (edge ③ gains `/renderPNG`, the message list gains `savePng`), the file table,
  the cross-runtime contracts table, and a new "Saving a PNG" section.
<img width="2144" height="1318" alt="image" src="https://github.com/user-attachments/assets/e1d55b23-bcc4-4522-a8ee-2dc87ba6a870" />
