### PR TITLE
Archive old artefacts

### DIFF
--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Build the extension, backend included
 #
-# Usage: scripts/build_release.sh [destination] [--force]
+# Usage: scripts/build_release.sh [destination]
 #
 # A release is one file: the .vsix carries the backend wheel, which the
 # extension installs into a virtual environment of its own the first time a
@@ -9,35 +9,41 @@
 # what keeps the frontend -- shipped inside the wheel -- in step with the
 # extension talking to it.
 #
-# If destination already contains a published release, publishing aborts unless
-# --force is given, so you don't accidentally clobber a colleague's
-# not-yet-downloaded release.
+# If destination already contains a published release, it's moved into
+# destination/old/ before the new one is installed.
 set -euo pipefail
 shopt -s nullglob
 
 REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 DEST=${1:-}
-FORCE=0
-for arg in "$@"; do
-	[[ $arg == --force ]] && FORCE=1
-done
 
 cd "$REPO"
+
+archive_old() {
+	local dest=$1
+	shift
+	local files=("$@")
+	(( ${#files[@]} )) || return 0
+	mkdir -p "$dest/old"
+	mv -f "${files[@]}" "$dest/old/"
+}
 
 # The backend wheel is built straight into the extension, because that is where
 # it ships from: plantuml-extension/backend/ is inside the vsix packaged below.
 # Cleared first because the extension globs for exactly one wheel, and a version
-# bump would otherwise leave the previous one beside it.
+# bump would otherwise leave the previous one beside it. This is a build
+# intermediate, not a release artefact, so it's discarded rather than archived.
 rm -rf plantuml-extension/backend
 mkdir -p plantuml-extension/backend
 uv build --wheel --out-dir plantuml-extension/backend
 
-# The extension -> plantuml-extension/, cleared for the same reason. npm ci
-# because the browser libraries are bundled into the vsix, and lint because
-# packaging runs no checks of its own. Lint only: `npm test` launches a real
-# VS Code and needs a display, which a build host will not have.
+# The extension -> plantuml-extension/, cleared the same way. npm ci because
+# the browser libraries are bundled into the vsix, and lint because packaging
+# runs no checks of its own. Lint only: `npm test` launches a real VS Code and
+# needs a display, which a build host will not have.
 cd plantuml-extension
-rm -f ./*.vsix
+old_vsix=(./*.vsix)
+archive_old . "${old_vsix[@]}"
 npm ci
 npm run lint
 npm run package
@@ -50,18 +56,10 @@ ls -1 plantuml-extension/backend/plantuml_gui-*.whl plantuml-extension/plantuml-
 
 # Only one release may be live: the install instructions glob the version out of
 # the filename, so a leftover would make the glob match two files. The wheel is
-# matched too, to clear the separately published one that releases up to 0.31
-# left there.
+# matched too, to archive the separately published one that releases up to
+# 0.31 left there.
 old=("$DEST"/plantuml-editor-*.vsix "$DEST"/plantuml_gui-*.whl)
-if (( ${#old[@]} )); then
-	if (( ! FORCE )); then
-		echo "error: $DEST already contains a published release:" >&2
-		printf '  %s\n' "${old[@]}" >&2
-		echo "rerun with --force to overwrite" >&2
-		exit 1
-	fi
-	rm -f "${old[@]}"
-fi
+archive_old "$DEST" "${old[@]}"
 
 # 664 so a colleague can publish the next release over yours
 install -m 664 plantuml-extension/plantuml-editor-*.vsix "$DEST/"


### PR DESCRIPTION
scripts/build_release.sh used to rm -f old wheels/vsix before rebuilding, and refused to overwrite an existing published release in $DEST unless --force was passed. Since publishing is now always safe (old files are preserved, not lost), the --force gate is no longer needed. Now in archive_old: helper that moves matched files into an old/ subfolder instead of deleting them.