### PR TITLE
Change New > Empty default to a generic placeholder comment

### DIFF
--- a/src/plantuml_gui/static/script.js
+++ b/src/plantuml_gui/static/script.js
@@ -260,7 +260,7 @@ function buttonEventListeners() {
     });
 
     document.getElementById('clear').addEventListener('click', function() {
-        puml = "@startuml\nstart\n@enduml"
+        puml = "@startuml\n' Add your PlantUML code here\n@enduml"
         setPuml(puml)
     });
 


### PR DESCRIPTION
Clicking "New", then "Empty" displays

<img width="2553" height="765" alt="image" src="https://github.com/user-attachments/assets/532c614d-0a46-4a27-bfe3-545fcd0a739d" />

Instead of previous with a start node, which was specifically for Activity diagrams
